### PR TITLE
Added shell app

### DIFF
--- a/src/apolo_app_types/shell.py
+++ b/src/apolo_app_types/shell.py
@@ -1,5 +1,6 @@
 from apolo_app_types.common import AppInputs, AppOutputs
 
+
 class ShellInputs(AppInputs):
     preset_name: str
     http_auth: bool = True


### PR DESCRIPTION
This pull request introduces new input and output classes for the shell application in the `src/apolo_app_types/shell.py` file. The most important changes include defining the `ShellInputs` and `ShellOutputs` classes, which inherit from common application input and output classes.

New input and output classes for shell application:

* [`src/apolo_app_types/shell.py`](diffhunk://#diff-adc53c31e6507a1ff25671dc0bd2defddf3a175752179bb1727cc1c17fabc66aR1-R10): Added `ShellInputs` class with `preset_name` and `http_auth` attributes, and `ShellOutputs` class with `internal_web_app_url` and `external_web_app_url` attributes.