### PR TITLE
added notebook type param

### DIFF
--- a/src/apolo_app_types/jupyter.py
+++ b/src/apolo_app_types/jupyter.py
@@ -1,9 +1,17 @@
+from enum import Enum
+
 from apolo_app_types.common import AppInputs, AppOutputs
+
+
+class JupyterTypes(str, Enum):
+    LAB = "lab"
+    NOTEBOOK = "notebook"
 
 
 class JupyterInputs(AppInputs):
     preset_name: str
     http_auth: bool = True
+    jupyter_type: JupyterTypes = JupyterTypes.LAB
 
 
 class JupyterOutputs(AppOutputs):


### PR DESCRIPTION
This pull request introduces a new enumeration to handle different Jupyter types and updates the `JupyterInputs` class to include this new enumeration.

**Enhancements to Jupyter types handling:**

* [`src/apolo_app_types/jupyter.py`](diffhunk://#diff-da35a833114559d95a2f29c3dd9ec6a4786bb57b317c908c6f50f509cc081abcR1-R14): Added the `JupyterTypes` enumeration to represent different Jupyter types (`LAB` and `NOTEBOOK`).
* [`src/apolo_app_types/jupyter.py`](diffhunk://#diff-da35a833114559d95a2f29c3dd9ec6a4786bb57b317c908c6f50f509cc081abcR1-R14): Updated the `JupyterInputs` class to include a new attribute `jupyter_type` with a default value of `JupyterTypes.LAB`.