### PR TITLE
bugfix: made LLMAPI inherit from basemodel

### DIFF
--- a/src/apolo_app_types/llm.py
+++ b/src/apolo_app_types/llm.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 from apolo_app_types.common import AppInputs, AppOutputs, Ingress
 
 
-class LLMApi:
+class LLMApi(BaseModel):
     replicas: int | None
     preset_name: str
 


### PR DESCRIPTION
This pull request includes a small bugfix to the `src/apolo_app_types/llm.py` file. The change involves modifying the `LLMApi` class to inherit from `BaseModel`. Without this, we cannot import the vLLM and TextEmbedding models (which depends on vLLM), making it impossible to install either application.

* [`src/apolo_app_types/llm.py`](diffhunk://#diff-b1be80c867d6ee018f630a69a823b72fe6100f178013d2ed3f55edc383e0126aL6-R6): Changed the `LLMApi` class to inherit from `BaseModel` to leverage Pydantic's data validation and serialization capabilities.


Unit tests in mlops-app-deployment before:

![image](https://github.com/user-attachments/assets/d6a0f73f-79da-400a-b11a-dfeb0d076a89)

and after changes:

![image](https://github.com/user-attachments/assets/1fe49f6a-2eae-458a-a285-640a7378f889)
