### PR TITLE
removed mlflow uris and added mlflow app name to apolo-deploy

### DIFF
--- a/src/apolo_app_types/apolo_deploy.py
+++ b/src/apolo_app_types/apolo_deploy.py
@@ -1,24 +1,10 @@
-from pydantic import field_validator
-from yarl import URL
-
 from apolo_app_types.common import AppInputs, AppOutputs
 
 
 class ApoloDeployInputs(AppInputs):
     preset_name: str
     http_auth: bool = True
-    mlflow_tracking_uri: URL | None = None
-    mlflow_public_uri: URL | None = None
-
-    @field_validator("mlflow_tracking_uri", mode="before")
-    @classmethod
-    def mlflow_tracking_uri_validator(cls, raw: str) -> URL:
-        return URL(raw)
-
-    @field_validator("mlflow_public_uri", mode="before")
-    @classmethod
-    def mlflow_public_uri_validator(cls, raw: str) -> URL:
-        return URL(raw)
+    mlflow_app_name: str
 
 
 class ApoloDeployOutputs(AppOutputs):


### PR DESCRIPTION
This PR removes the need to pass `mlflow_tracking_uri` and `mlflow_public_uri` to Apolo Deploy application. Instead it expects a `mlflow_app_name` and the `ApoloDeployAppManager` in `mlops-app-deployment` gets the necessary urls using apolo sdk (like PrivateGPT does).