### PR TITLE
Make Update Outputs fail in case of any error

### DIFF
--- a/src/apolo_app_types/cli.py
+++ b/src/apolo_app_types/cli.py
@@ -34,11 +34,16 @@ def update_outputs(
         logger.info("Helm input: %s", helm_outputs_json)
         helm_outputs_dict = json.loads(helm_outputs_json)
         logger.info("Helm outputs: %s", helm_outputs_dict)
-        asyncio.run(update_app_outputs(helm_outputs_dict))
+        result = asyncio.run(update_app_outputs(helm_outputs_dict))
+        if not result:
+            m = "Failed to run update_app_outputs"
+            raise Exception(m)
     except json.JSONDecodeError as e:
         logger.error("Failed to parse JSON input: %s", e)
+        sys.exit(1)
     except Exception as e:
         logger.error("An error occurred: %s", e)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/apolo_app_types/outputs/update_outputs.py
+++ b/src/apolo_app_types/outputs/update_outputs.py
@@ -32,7 +32,7 @@ async def post_outputs(api_url: str, api_token: str, outputs: dict[str, t.Any]) 
         )
 
 
-async def update_app_outputs(helm_outputs: dict[str, t.Any]) -> None:
+async def update_app_outputs(helm_outputs: dict[str, t.Any]) -> bool:
     app_type = helm_outputs["PLATFORM_APPS_APP_TYPE"]
     platform_apps_url = helm_outputs["PLATFORM_APPS_URL"]
     platform_apps_token = helm_outputs["PLATFORM_APPS_TOKEN"]
@@ -63,3 +63,5 @@ async def update_app_outputs(helm_outputs: dict[str, t.Any]) -> None:
         )
     except Exception as e:
         logger.error("An error occurred: %s", e)
+        return False
+    return True


### PR DESCRIPTION
This PR makes the `app-types update-outputs` cli actually return an error when something fails. Right now it just prints an error message, but does not return an exit code != 0, so for ArgoCD it looks like everything went OK.

I altered the return type of `update_outputs` because `asyncio.run` does not propagate the exceptions, even if you explicitly  raise them inside the async code.

This pull request includes changes to improve error handling in the `update_app_outputs` function and its usage. The most important changes include modifying the return type of `update_app_outputs`, handling the function's result in `update_outputs`, and ensuring the application exits on errors.

Improvements to error handling:

* [`src/apolo_app_types/cli.py`](diffhunk://#diff-a57b9865b6c94522229e2ff54742617329149742c8e5a733f8734947b5eb2c98L37-R46): Modified `update_outputs` to handle the result of `update_app_outputs` and raise an exception if it fails. Added `sys.exit(1)` to ensure the application exits on errors.
* [`src/apolo_app_types/outputs/update_outputs.py`](diffhunk://#diff-c755e1434d7c19baaafc44d20743e4faa6706f067ead1fca962a38148ffac5eaL35-R35): Changed the return type of `update_app_outputs` from `None` to `bool` to indicate success or failure.
* [`src/apolo_app_types/outputs/update_outputs.py`](diffhunk://#diff-c755e1434d7c19baaafc44d20743e4faa6706f067ead1fca962a38148ffac5eaR66-R67): Updated `update_app_outputs` to return `False` on exceptions and `True` on success.