### PR TITLE
Simplified Spark installation by removing top level model and grouped other inputs

### DIFF
--- a/src/apolo_app_types/helm/apps/spark_job.py
+++ b/src/apolo_app_types/helm/apps/spark_job.py
@@ -66,12 +66,12 @@ class SparkJobValueProcessor(BaseChartValueProcessor[SparkJobInputs]):
         # Labels and annotations
         driver_extra_values = await gen_extra_values(
             apolo_client=self.client,
-            preset_type=input_.driver_preset,
+            preset_type=input_.driver_config.preset,
             namespace=namespace,
         )
         executor_extra_values = await gen_extra_values(
             apolo_client=self.client,
-            preset_type=input_.executor_preset,
+            preset_type=input_.executor_config.preset,
             namespace=namespace,
         )
         extra_labels = gen_apolo_storage_integration_labels(inject_storage=True)
@@ -91,7 +91,7 @@ class SparkJobValueProcessor(BaseChartValueProcessor[SparkJobInputs]):
                 },
                 "driver": {
                     "labels": {
-                        "platform.apolo.us/preset": input_.driver_preset.name,  # noqa: E501
+                        "platform.apolo.us/preset": input_.driver_config.preset.name,  # noqa: E501
                         "platform.apolo.us/component": "app",
                         **extra_labels,
                     },
@@ -100,11 +100,12 @@ class SparkJobValueProcessor(BaseChartValueProcessor[SparkJobInputs]):
                 },
                 "executor": {
                     "labels": {
-                        "platform.apolo.us/preset": input_.executor_preset.name,  # noqa: E501
+                        "platform.apolo.us/preset": input_.executor_config.preset.name,  # noqa: E501
                         "platform.apolo.us/component": "app",
                         **extra_labels,
                     },
                     "annotations": storage_annotations,
+                    "instances": input_.executor_config.instances,
                     **executor_extra_values,
                 },
             },

--- a/src/apolo_app_types/protocols/spark_job.py
+++ b/src/apolo_app_types/protocols/spark_job.py
@@ -21,27 +21,106 @@ class SparkApplicationType(StrEnum):
     R = "R"
 
 
-class SparkExecutorConfig(AbstractAppFieldType):
-    instances: int
+class DriverConfig(AbstractAppFieldType):
+    preset: Preset = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Driver Preset",
+            description="Preset configuration to be used by the driver",
+        ).as_json_schema_extra(),
+    )
+
+
+class ExecutorConfig(AbstractAppFieldType):
+    instances: int = Field(
+        default=1, title="Instances", description="Number of instances"
+    )
+    preset: Preset = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Executor Preset",
+            description="Preset configuration to be used by the executor",
+        ).as_json_schema_extra(),
+    )
 
 
 class SparkDependencies(AbstractAppFieldType):
-    jars: list[str] | None = None
-    py_files: list[str] | None = None
-    files: list[str] | None = None
-    packages: list[str] | None = None
-    exclude_packages: list[str] | None = None
-    repositories: list[str] | None = None
-    archives: list[str] | None = None
-    pypi_packages: list[str] | ApoloFilesFile | None = None
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Spark Dependencies",
+            description="Dependencies for the Spark application",
+        ).as_json_schema_extra(),
+    )
+    jars: list[str] | None = Field(
+        default=None,
+        title="Jars",
+        description="List of jars to be included as dependencies",
+    )
+    py_files: list[str] | None = Field(
+        default=None,
+        title="Python Files",
+        description="List of Python files to be included as dependencies",
+    )
+    files: list[str] | None = Field(
+        default=None,
+        title="Files",
+        description="List of files to be included as dependencies",
+    )
+    packages: list[str] | None = Field(
+        default=None,
+        title="Packages",
+        description="List of packages to be included as dependencies",
+    )
+    exclude_packages: list[str] | None = Field(
+        default=None,
+        title="Exclude Packages",
+        description="List of packages to be excluded as dependencies",
+    )
+    repositories: list[str] | None = Field(
+        default=None,
+        title="Repositories",
+        description="List of repositories to be included as dependencies",
+    )
+    archives: list[str] | None = Field(
+        default=None,
+        title="Archives",
+        description="List of archives to be included as dependencies",
+    )
+    pypi_packages: list[str] | ApoloFilesFile | None = Field(
+        default=None,
+        title="PyPi Packages",
+        description=(
+            "List of PyPi packages to be downloaded and included as dependencies"
+        ),
+    )
 
 
 class SparkAutoScalingConfig(AbstractAppFieldType):
-    enabled: bool = False
-    initial_executors: int | None
-    min_executors: int
-    max_executors: int
-    shuffle_tracking_timeout: int
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Spark Auto Scaling Configuration",
+            description="Configuration for the Spark auto scaling",
+        ).as_json_schema_extra(),
+    )
+    enabled: bool = Field(
+        default=False, title="Enabled", description="Enable auto scaling"
+    )
+    initial_executors: int | None = Field(
+        default=None,
+        title="Initial Executors",
+        description="Initial number of executors",
+    )
+    min_executors: int = Field(
+        default=1, title="Min Executors", description="Minimum number of executors"
+    )
+    max_executors: int = Field(
+        default=1, title="Max Executors", description="Maximum number of executors"
+    )
+    shuffle_tracking_timeout: int = Field(
+        ..., title="Shuffle Tracking Timeout", description="Shuffle tracking timeout"
+    )
 
 
 class SparkApplicationConfig(AbstractAppFieldType):
@@ -90,18 +169,18 @@ class SparkJobInputs(AppInputs):
             description="Configuration for the Spark auto scaling",
         ).as_json_schema_extra(),
     )
-    driver_preset: Preset = Field(
+    driver_config: DriverConfig = Field(
         ...,
         json_schema_extra=SchemaExtraMetadata(
-            title="Driver Preset",
-            description="Preset configuration to be used by the driver",
+            title="Driver Configuration",
+            description="Configuration for the driver",
         ).as_json_schema_extra(),
     )
-    executor_preset: Preset = Field(
+    executor_config: ExecutorConfig = Field(
         ...,
         json_schema_extra=SchemaExtraMetadata(
-            title="Executor Preset",
-            description="Preset configuration to be used by the executor",
+            title="Executor Configuration",
+            description="Configuration for the executor",
         ).as_json_schema_extra(),
     )
 

--- a/tests/unit/test_spark_job_input_generation.py
+++ b/tests/unit/test_spark_job_input_generation.py
@@ -9,6 +9,8 @@ from apolo_app_types.inputs.args import app_type_to_vals
 from apolo_app_types.protocols.common import Preset
 from apolo_app_types.protocols.common.storage import ApoloFilesFile
 from apolo_app_types.protocols.spark_job import (
+    DriverConfig,
+    ExecutorConfig,
     SparkApplicationConfig,
     SparkApplicationType,
     SparkAutoScalingConfig,
@@ -29,8 +31,10 @@ async def test_spark_job_values_generation(setup_clients):
                     pypi_packages=["scikit-learn==1.0.2"],
                 ),
             ),
-            driver_preset=Preset(name="cpu-small"),
-            executor_preset=Preset(name="cpu-medium"),
+            driver_config=DriverConfig(preset=Preset(name="cpu-small")),
+            executor_config=ExecutorConfig(
+                preset=Preset(name="cpu-medium"), instances=1
+            ),
             image=ContainerImage(repository="myrepo/spark-job", tag="v1.2.3"),
             spark_auto_scaling_config=SparkAutoScalingConfig(
                 enabled=True,


### PR DESCRIPTION
This pull request includes significant changes to the `spark_job.py` and `spark_job.py` files to refactor and simplify the configuration structure for Spark jobs. The primary focus is on consolidating the configuration classes and updating the related methods to use the new structure.

Key changes include:

### Refactoring Configuration Structure:
* Removed `PythonSpecificConfig` and `JavaSpecificConfig` classes and integrated their attributes into the `SparkDependencies` and `SparkApplicationConfig` classes (`src/apolo_app_types/protocols/spark_job.py`). [[1]](diffhunk://#diff-ae68b345bd34a7fd518bfcf5106a6e83c8c8f15465518d34a76ceb28b723a0bcL28-L35) [[2]](diffhunk://#diff-ae68b345bd34a7fd518bfcf5106a6e83c8c8f15465518d34a76ceb28b723a0bcR36) [[3]](diffhunk://#diff-ae68b345bd34a7fd518bfcf5106a6e83c8c8f15465518d34a76ceb28b723a0bcL54-L71) [[4]](diffhunk://#diff-ae68b345bd34a7fd518bfcf5106a6e83c8c8f15465518d34a76ceb28b723a0bcR63-R83) [[5]](diffhunk://#diff-ae68b345bd34a7fd518bfcf5106a6e83c8c8f15465518d34a76ceb28b723a0bcL109-L113)
* Updated `SparkApplicationModel` to `SparkApplicationConfig` and moved relevant attributes (`src/apolo_app_types/protocols/spark_job.py`). [[1]](diffhunk://#diff-ae68b345bd34a7fd518bfcf5106a6e83c8c8f15465518d34a76ceb28b723a0bcL54-L71) [[2]](diffhunk://#diff-ae68b345bd34a7fd518bfcf5106a6e83c8c8f15465518d34a76ceb28b723a0bcR63-R83)

### Updating Methods to Use New Configuration:
* Modified `_configure_application_storage` method to use `spark_application_config` instead of `spark_job` (`src/apolo_app_types/helm/apps/spark_job.py`).
* Updated `gen_extra_values` method to reflect changes in configuration structure (`src/apolo_app_types/helm/apps/spark_job.py`). [[1]](diffhunk://#diff-bbe06052ddde6b5cc81e3fe1720235d987b2bee996adb5e1c4ec7330d6ccd3b3L69-R74) [[2]](diffhunk://#diff-bbe06052ddde6b5cc81e3fe1720235d987b2bee996adb5e1c4ec7330d6ccd3b3L86-R94) [[3]](diffhunk://#diff-bbe06052ddde6b5cc81e3fe1720235d987b2bee996adb5e1c4ec7330d6ccd3b3L102-R103) [[4]](diffhunk://#diff-bbe06052ddde6b5cc81e3fe1720235d987b2bee996adb5e1c4ec7330d6ccd3b3L120-R127)
* Refactored `add_dependencies` method to use the new `dependencies` attribute in `spark_application_config` (`src/apolo_app_types/helm/apps/spark_job.py`).

### Test Adjustments:
* Updated unit tests to align with the new configuration structure (`tests/unit/test_spark_job_input_generation.py`).