### PR TITLE
hotfix for post-install script with commands that have single quotes

### DIFF
--- a/charts/hook/templates/post-install.yaml
+++ b/charts/hook/templates/post-install.yaml
@@ -20,5 +20,6 @@ spec:
         image: {{ .Values.appTypesImage.repository }}:{{ .Values.appTypesImage.tag }}
         args:
         - "update-outputs"
-        - {{ include "filterNonEmptyAndConvertToJson" .Values | squote }}
+        - >
+          {{ include "filterNonEmptyAndConvertToJson" .Values | squote }}
         imagePullPolicy: {{ .Values.appTypesImage.pullPolicy }}

--- a/src/apolo_app_types/helm/apps/jupyter.py
+++ b/src/apolo_app_types/helm/apps/jupyter.py
@@ -49,7 +49,7 @@ class JupyterChartValueProcessor(BaseChartValueProcessor[JupyterAppInputs]):
             f"--port {self._jupyter_port} "
             "--allow-root "
             "--NotebookApp.token= "
-            f"--notebook-dir={code_storage_mount.mount_path} "
+            f"--notebook-dir={code_storage_mount.mount_path.path} "
             # "--NotebookApp.shutdown_no_activity_timeout=7200 "
             # "--MappingKernelManager.cull_idle_timeout=7200 "
             # "--MappingKernelManager.cull_connected=True"
@@ -76,13 +76,16 @@ class JupyterChartValueProcessor(BaseChartValueProcessor[JupyterAppInputs]):
             ),
             container=Container(
                 command=[
+                    "bash",
+                    "-c",
                     (
-                        f'bash -c "(rsync -a --ignore-existing '
+                        f"(mkdir -p {code_storage_mount.mount_path.path}) && "
+                        "(rsync -a --ignore-existing "
                         "/var/notebooks/README.ipynb "
-                        f"{code_storage_mount.mount_path}) && "
+                        f"{code_storage_mount.mount_path.path}) && "
                         f"(jupyter {cmd} {jupyter_args} "
-                        f'--NotebookApp.default_url={code_storage_mount.mount_path}/README.ipynb)"'
-                    )
+                        f"--NotebookApp.default_url={code_storage_mount.mount_path.path}/README.ipynb)"
+                    ),
                 ],
                 env=env_vars,
             ),


### PR DESCRIPTION
Fixes a rare case where CustomDeployment `command` contains a single quote and causes the yaml structure to fail because it is not escaped.

And fix for Jupyter app commands

Example of wrong yaml generated: 

```yaml
---
# Source: post-outputs/templates/post-install.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: release-name-post-outputs
  labels:
    application: hook
    helm.sh/chart: post-outputs-0.1.0
    app.kubernetes.io/name: post-outputs
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
    argocd.argoproj.io/hook: PostSync
    argocd.argoproj.io/sync-wave: "1"
spec:
  template:
    metadata:
      labels:
        application: hook
        helm.sh/chart: post-outputs-0.1.0
        app.kubernetes.io/name: post-outputs
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "1.16.0"
        app.kubernetes.io/managed-by: Helm
    spec:
      restartPolicy: Never
      serviceAccountName: release-name-sa
      containers:
      - name: post-upgrade-hook
        image: ghcr.io/neuro-inc/post-deployment-app-hook:development
        args:
        - "update-outputs"
        - '{"PLATFORM_APPS_APP_TYPE":"jupyter","PLATFORM_APPS_TOKEN":"token","PLATFORM_APPS_URL":"http://platform-apps.default.svc.cluster.local:8080/apis/apps/v1/cluster/default/org/apolo/project/jordy-dev/instances/7479d0dc3c95413583a28e7b7a2a82c2/output","affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"platform.neuromation.io/nodepool","operator":"In","values":["default"]}]}]}}},"appTypesImage":{"pullPolicy":"Always","repository":"ghcr.io/neuro-inc/post-deployment-app-hook","tag":"development"},"container":{"args":null,"command":["bash -c \"(rsync -a --ignore-existing /var/notebooks/README.ipynb path='/root/notebooks') \u0026\u0026 (jupyter lab --no-browser --ip=0.0.0.0 --port 8888 --allow-root --NotebookApp.token= --notebook-dir=path='/root/notebooks'  --NotebookApp.default_url=path='/root/notebooks'/README.ipynb)\""],"env":[]},"fullnameOverride":"","image":{"repository":"ghcr.io/neuro-inc/base","tag":"pipelines"},"ingress":{"annotations":{"traefik.ingress.kubernetes.io/router.middlewares":"apolo-jordy-dev-jupyter-7479d0dc-forwardauth@kubernetescrd"},"className":"traefik","enabled":true,"forwardAuth":{"address":"https://api.dev.apolo.us/oauth/authorize","enabled":true,"name":"forwardauth","trustForwardHeader":true},"grpc":{"enabled":false},"hosts":[{"host":"apolo-jordy-dev-jupyter-7479d0dc.apps.dev.apolo.us","paths":[{"path":"/","pathType":"Prefix","portName":"http"}]}]},"labels":{"application":"jupyter"},"nameOverride":"","podAnnotations":{"platform.apolo.us/inject-storage":"[{\"storage_uri\": \"storage://default/apolo/jordy-dev/.apps/jupyter/jupyter-app/code\", \"mount_path\": \"/root/notebooks\", \"mount_mode\": \"rw\"}]"},"podLabels":{"platform.apolo.us/inject-storage":"true","platform.apolo.us/org":"apolo","platform.apolo.us/project":"jordy-dev"},"preset_name":"cpu-small","resources":{"limits":{"cpu":"1000m","memory":"0M"},"requests":{"cpu":"1000m","memory":"0M"}},"service":{"enabled":true,"ports":[{"containerPort":8888,"name":"http"}]},"tolerations":[{"effect":"NoSchedule","key":"platform.neuromation.io/job","operator":"Exists"},{"effect":"NoExecute","key":"node.kubernetes.io/not-ready","operator":"Exists","tolerationSeconds":300},{"effect":"NoExecute","key":"node.kubernetes.io/unreachable","operator":"Exists","tolerationSeconds":300}]}'
        imagePullPolicy: Always
```

Fixed yaml:

```yaml
---
# Source: post-outputs/templates/post-install.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: release-name-post-outputs
  labels:
    application: hook
    helm.sh/chart: post-outputs-0.1.0
    app.kubernetes.io/name: post-outputs
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
    argocd.argoproj.io/hook: PostSync
    argocd.argoproj.io/sync-wave: "1"
spec:
  template:
    metadata:
      labels:
        application: hook
        helm.sh/chart: post-outputs-0.1.0
        app.kubernetes.io/name: post-outputs
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "1.16.0"
        app.kubernetes.io/managed-by: Helm
    spec:
      restartPolicy: Never
      serviceAccountName: release-name-sa
      containers:
      - name: post-upgrade-hook
        image: ghcr.io/neuro-inc/post-deployment-app-hook:development
        args:
        - "update-outputs"
        - >
          '{"PLATFORM_APPS_APP_TYPE":"jupyter","PLATFORM_APPS_TOKEN":"token","PLATFORM_APPS_URL":"http://platform-apps.default.svc.cluster.local:8080/apis/apps/v1/cluster/default/org/apolo/project/jordy-dev/instances/7479d0dc3c95413583a28e7b7a2a82c2/output","affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"platform.neuromation.io/nodepool","operator":"In","values":["default"]}]}]}}},"appTypesImage":{"pullPolicy":"Always","repository":"ghcr.io/neuro-inc/post-deployment-app-hook","tag":"development"},"container":{"args":null,"command":["bash -c \"(rsync -a --ignore-existing /var/notebooks/README.ipynb path='/root/notebooks') \u0026\u0026 (jupyter lab --no-browser --ip=0.0.0.0 --port 8888 --allow-root --NotebookApp.token= --notebook-dir=path='/root/notebooks'  --NotebookApp.default_url=path='/root/notebooks'/README.ipynb)\""],"env":[]},"fullnameOverride":"","image":{"repository":"ghcr.io/neuro-inc/base","tag":"pipelines"},"ingress":{"annotations":{"traefik.ingress.kubernetes.io/router.middlewares":"apolo-jordy-dev-jupyter-7479d0dc-forwardauth@kubernetescrd"},"className":"traefik","enabled":true,"forwardAuth":{"address":"https://api.dev.apolo.us/oauth/authorize","enabled":true,"name":"forwardauth","trustForwardHeader":true},"grpc":{"enabled":false},"hosts":[{"host":"apolo-jordy-dev-jupyter-7479d0dc.apps.dev.apolo.us","paths":[{"path":"/","pathType":"Prefix","portName":"http"}]}]},"labels":{"application":"jupyter"},"nameOverride":"","podAnnotations":{"platform.apolo.us/inject-storage":"[{\"storage_uri\": \"storage://default/apolo/jordy-dev/.apps/jupyter/jupyter-app/code\", \"mount_path\": \"/root/notebooks\", \"mount_mode\": \"rw\"}]"},"podLabels":{"platform.apolo.us/inject-storage":"true","platform.apolo.us/org":"apolo","platform.apolo.us/project":"jordy-dev"},"preset_name":"cpu-small","resources":{"limits":{"cpu":"1000m","memory":"0M"},"requests":{"cpu":"1000m","memory":"0M"}},"service":{"enabled":true,"ports":[{"containerPort":8888,"name":"http"}]},"tolerations":[{"effect":"NoSchedule","key":"platform.neuromation.io/job","operator":"Exists"},{"effect":"NoExecute","key":"node.kubernetes.io/not-ready","operator":"Exists","tolerationSeconds":300},{"effect":"NoExecute","key":"node.kubernetes.io/unreachable","operator":"Exists","tolerationSeconds":300}]}'
        imagePullPolicy: Always
```

Screenshots of Jupyter application deployed locally:

![image](https://github.com/user-attachments/assets/eb37a94c-56a7-4516-9976-55a8926587b1)
![image](https://github.com/user-attachments/assets/0ab3c37d-5765-4732-b4c0-644fef10e852)
