### PR TITLE
Update Jupyter container image tag to v25.3.0-runtime

### DIFF
--- a/src/apolo_app_types/helm/apps/jupyter.py
+++ b/src/apolo_app_types/helm/apps/jupyter.py
@@ -72,7 +72,7 @@ class JupyterChartValueProcessor(BaseChartValueProcessor[JupyterAppInputs]):
             preset=input_.preset,
             image=ContainerImage(
                 repository="ghcr.io/neuro-inc/base",
-                tag="pipelines",
+                tag="v25.3.0-runtime",
             ),
             container=Container(
                 command=[


### PR DESCRIPTION
Updating Jupyter app image because we were having issues starting Jupyter Lab with the old one.

Examples:
![Screenshot From 2025-04-28 09-32-14](https://github.com/user-attachments/assets/c62b8a1d-be6f-4755-bb35-437cafca9cf1)
![Screenshot From 2025-04-28 09-32-53](https://github.com/user-attachments/assets/699ec460-1822-408f-985e-40220c875157)

Now:

