### PR TITLE
MLO-212: Update release name to weaviate so it is used for outputs

### DIFF
--- a/src/apolo_app_types/outputs/weaviate.py
+++ b/src/apolo_app_types/outputs/weaviate.py
@@ -37,7 +37,7 @@ async def _get_service_endpoints(
 
 
 async def get_weaviate_outputs(helm_values: dict[str, t.Any]) -> dict[str, t.Any]:
-    release_name = helm_values.get("nameOverride", "weaviate")
+    release_name = "weaviate"
     cluster_api = helm_values.get("clusterApi", {})
 
     try:


### PR DESCRIPTION
nameOverride is by default empty string and that's why it can't find the services when searching for `application: weaviate label`