### PR TITLE
MLO-205: Add Service deployment app type

### DIFF
--- a/src/apolo_app_types/app_types.py
+++ b/src/apolo_app_types/app_types.py
@@ -32,6 +32,7 @@ class AppType(enum.StrEnum):
     DockerHub = "dockerhub"
     HuggingFaceCache = "huggingface-cache"
     CustomDeployment = "custom-deployment"
+    ServiceDeployment = "service-deployment"
     SparkJob = "spark-job"
 
     def __repr__(self) -> str:


### PR DESCRIPTION
In some of our app reviews, @dalazx mentioned we might need a better name for custom deployment app.

This PR adds one introduced in https://github.com/neuro-inc/mlops-custom-deployment-app/blob/master/.apolo/src/apolo_apps_service_deployment/__init__.py#L13