### PR TITLE
Add database names to PostgreSQL user configuration

### DIFF
--- a/src/apolo_app_types/helm/apps/postgres.py
+++ b/src/apolo_app_types/helm/apps/postgres.py
@@ -94,6 +94,7 @@ class PostgresValueProcessor(BaseChartValueProcessor[PostgresInputs]):
                 {
                     "name": db_user.name,
                     "password": {"type": "AlphaNumeric"},
+                    "databases": db_user.db_names,
                 }
             )
         return users_config

--- a/tests/unit/postgres/test_postgres_input_generator.py
+++ b/tests/unit/postgres/test_postgres_input_generator.py
@@ -80,7 +80,11 @@ async def test_values_postgresql_generation(setup_clients, mock_get_preset_cpu):
     assert "podAntiAffinity" in helm_params["instances"][0]["affinity"]
     assert helm_params["users"] == [
         {"name": "postgres"},
-        {"name": "some_name", "password": {"type": "AlphaNumeric"}},
+        {
+            "name": "some_name",
+            "password": {"type": "AlphaNumeric"},
+            "databases": ["some_db"],
+        },
     ]
 
 


### PR DESCRIPTION
This update ensures that each PostgreSQL user is associated with specific database names by including the "databases" field in the user configuration. It enhances clarity and precision in mapping users to their respective databases.