### PR TITLE
fix issue generating mlflow integration url

### DIFF
--- a/src/apolo_app_types/helm/apps/jupyter.py
+++ b/src/apolo_app_types/helm/apps/jupyter.py
@@ -61,11 +61,11 @@ class JupyterChartValueProcessor(BaseChartValueProcessor[JupyterAppInputs]):
             cmd = "notebook"
 
         env_vars = []
-        if input_.mlflow_integration:
+        if input_.mlflow_integration and input_.mlflow_integration.internal_web_app_url:
             env_vars.append(
                 Env(
                     name="MLFLOW_TRACKING_URI",
-                    value=f"http://{input_.mlflow_integration.internal_web_app_url}",
+                    value=input_.mlflow_integration.internal_web_app_url.complete_url,
                 )
             )
 

--- a/src/apolo_app_types/helm/apps/vscode.py
+++ b/src/apolo_app_types/helm/apps/vscode.py
@@ -44,11 +44,11 @@ class VSCodeChartValueProcessor(BaseChartValueProcessor[VSCodeAppInputs]):
         env_vars = [
             Env(name="CODER_HTTP_ADDRESS", value=f"0.0.0.0:{self._port}"),
         ]
-        if input_.mlflow_integration:
+        if input_.mlflow_integration and input_.mlflow_integration.internal_web_app_url:
             env_vars.append(
                 Env(
                     name="MLFLOW_TRACKING_URI",
-                    value=f"http://{input_.mlflow_integration.internal_web_app_url}",
+                    value=input_.mlflow_integration.internal_web_app_url.complete_url,
                 )
             )
 

--- a/src/apolo_app_types/protocols/common/networking.py
+++ b/src/apolo_app_types/protocols/common/networking.py
@@ -47,8 +47,7 @@ class HttpApi(AbstractAppFieldType):
 
     @property
     def complete_url(self) -> str:
-        protocol = self.protocol or "http"
-        return f"{protocol}://{self.host}:{self.port}{self.base_path}"
+        return f"{self.protocol}://{self.host}:{self.port}{self.base_path}"
 
 
 class GraphQLAPI(HttpApi):

--- a/src/apolo_app_types/protocols/common/networking.py
+++ b/src/apolo_app_types/protocols/common/networking.py
@@ -45,6 +45,11 @@ class HttpApi(AbstractAppFieldType):
     )
     base_path: str = "/"
 
+    @property
+    def complete_url(self) -> str:
+        protocol = self.protocol or "http"
+        return f"{protocol}://{self.host}:{self.port}{self.base_path}"
+
 
 class GraphQLAPI(HttpApi):
     api_type: Literal["graphql"] = "graphql"


### PR DESCRIPTION
The current code for integrating MLFlow into Jupyter and VSCode generates the following invalid ulr:

```
http://host='apolo-jordy-dev-mlflow-core-c1336450-custom-deployment.apolo-jordy-dev-mlflow-core-c1336450' port=5000 protocol='http' timeout=30.0 base_path='/' api_type='rest'
```
