### PR TITLE
MLO-257: Add example arg string to prevent outputs parsing issues

### DIFF
--- a/src/apolo_app_types/protocols/llm.py
+++ b/src/apolo_app_types/protocols/llm.py
@@ -54,7 +54,7 @@ class LLMModel(AbstractAppFieldType):
         json_schema_extra=SchemaExtraMetadata(
             title="Server Extra Arguments",
             description="Configure extra arguments "
-            "to pass to the server (see VLLM doc).",
+            "to pass to the server (see VLLM doc, e.g. --max-model-len=131072).",
         ).as_json_schema_extra(),
     )
 


### PR DESCRIPTION
Looked at the implementation from llm inference issue, is i was sending

```
"server_extra_args": [   
        "--dtype", "bfloat16",
        "--max-model-len", "4096"
      ]
```
when i should have sent
```
 "server_extra_args": [   
        "--dtype=bfloat16",
        "--max-model-len=4096"
      ]
```

Added this helper text to avoid confusion for configuring args