### PR TITLE
App labels fixes

### DIFF
--- a/src/apolo_app_types/helm/apps/spark_job.py
+++ b/src/apolo_app_types/helm/apps/spark_job.py
@@ -125,7 +125,7 @@ class SparkJobValueProcessor(BaseChartValueProcessor[SparkJobInputs]):
     ) -> None:
         if input_.spark_auto_scaling_config:
             dynamic_allocation: dict[str, t.Any] = {
-                "enabled": (input_.spark_auto_scaling_config.enabled),
+                "enabled": True,
                 "initialExecutors": input_.spark_auto_scaling_config.initial_executors,  # noqa: E501
                 "minExecutors": input_.spark_auto_scaling_config.min_executors,  # noqa: E501
                 "maxExecutors": input_.spark_auto_scaling_config.max_executors,  # noqa: E501

--- a/src/apolo_app_types/protocols/mlflow.py
+++ b/src/apolo_app_types/protocols/mlflow.py
@@ -71,11 +71,23 @@ class MLFlowAppInputs(AppInputs):
 
 
 class MLFlowAppOutputs(AppOutputs):
-    """
-    MLFlow outputs:
-      - internal_web_app_url
-      - external_web_app_url
-    """
-
-    internal_web_app_url: RestAPI | None = None
-    external_web_app_url: RestAPI | None = None
+    internal_web_app_url: RestAPI | None = Field(
+        default=None,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Internal MLFlow URL",
+            description=(
+                "Internal URL to access the MLFlow web "
+                "app and API from inside the cluster."
+            ),
+        ).as_json_schema_extra(),
+    )
+    external_web_app_url: RestAPI | None = Field(
+        default=None,
+        json_schema_extra=SchemaExtraMetadata(
+            title="External MLFlow URL",
+            description=(
+                "External URL to access the MLFlow web "
+                "app and API from outside the cluster."
+            ),
+        ).as_json_schema_extra(),
+    )

--- a/src/apolo_app_types/protocols/spark_job.py
+++ b/src/apolo_app_types/protocols/spark_job.py
@@ -22,6 +22,13 @@ class SparkApplicationType(StrEnum):
 
 
 class DriverConfig(AbstractAppFieldType):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Driver Configuration",
+            description="Configure resources and environment for the Spark driver.",
+        ).as_json_schema_extra(),
+    )
     preset: Preset = Field(
         ...,
         json_schema_extra=SchemaExtraMetadata(
@@ -32,6 +39,15 @@ class DriverConfig(AbstractAppFieldType):
 
 
 class ExecutorConfig(AbstractAppFieldType):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Executor Configuration",
+            description=(
+                "Define the compute resources and behavior for Spark executors."
+            ),
+        ).as_json_schema_extra(),
+    )
     instances: int = Field(
         default=1,
         json_schema_extra=SchemaExtraMetadata(
@@ -137,14 +153,6 @@ class SparkAutoScalingConfig(AbstractAppFieldType):
         ).as_json_schema_extra(),
     )
 
-    enabled: bool = Field(
-        default=False,
-        json_schema_extra=SchemaExtraMetadata(
-            title="Auto Scaling Enabled",
-            description="Enable or disable automatic scaling of Spark executors.",
-        ).as_json_schema_extra(),
-    )
-
     initial_executors: int | None = Field(
         default=None,
         json_schema_extra=SchemaExtraMetadata(
@@ -183,6 +191,13 @@ class SparkAutoScalingConfig(AbstractAppFieldType):
 
 
 class SparkApplicationConfig(AbstractAppFieldType):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="App Settings",
+            description="Configure the main application file, type, and arguments.",
+        ).as_json_schema_extra(),
+    )
     type: SparkApplicationType = Field(
         ...,
         json_schema_extra=SchemaExtraMetadata(

--- a/src/apolo_app_types/protocols/spark_job.py
+++ b/src/apolo_app_types/protocols/spark_job.py
@@ -14,6 +14,9 @@ from apolo_app_types.protocols.common import (
 )
 
 
+_SPARK_DEFAULT_IMAGE = ("spark", "3.5.3")
+
+
 class SparkApplicationType(StrEnum):
     PYTHON = "Python"
     SCALA = "Scala"
@@ -194,7 +197,7 @@ class SparkApplicationConfig(AbstractAppFieldType):
     model_config = ConfigDict(
         protected_namespaces=(),
         json_schema_extra=SchemaExtraMetadata(
-            title="App Settings",
+            title="Spark App Settings",
             description="Configure the main application file, type, and arguments.",
         ).as_json_schema_extra(),
     )
@@ -263,15 +266,6 @@ class SparkJobInputs(AppInputs):
         ).as_json_schema_extra(),
     )
 
-    image: ContainerImage = Field(
-        default=ContainerImage(repository="spark", tag="3.5.3"),
-        json_schema_extra=SchemaExtraMetadata(
-            title="Container Image",
-            description="Specify the container image "
-            "to run your Spark job. Defaults to the latest Spark version.",
-        ).as_json_schema_extra(),
-    )
-
     spark_application_config: SparkApplicationConfig = Field(
         ...,
         json_schema_extra=SchemaExtraMetadata(
@@ -290,11 +284,25 @@ class SparkJobInputs(AppInputs):
         ).as_json_schema_extra(),
     )
 
+    image: ContainerImage = Field(
+        default=ContainerImage(
+            repository=_SPARK_DEFAULT_IMAGE[0], tag=_SPARK_DEFAULT_IMAGE[1]
+        ),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Spark Container Image",
+            description="Modify this to select the container image used "
+            "to run your Spark job. Defaults to "
+            "{_SPARK_DEFAULT_IMAGE[0]}:{_SPARK_DEFAULT_IMAGE[1]}.",
+            is_advanced_field=True,
+        ).as_json_schema_extra(),
+    )
+
     driver_config: DriverConfig = Field(
         ...,
         json_schema_extra=SchemaExtraMetadata(
             title="Driver Configuration",
             description="Configure resources and environment for the Spark driver.",
+            is_advanced_field=True,
         ).as_json_schema_extra(),
     )
 
@@ -304,6 +312,7 @@ class SparkJobInputs(AppInputs):
             title="Executor Configuration",
             description="Define the compute resources "
             "and behavior for Spark executors.",
+            is_advanced_field=True,
         ).as_json_schema_extra(),
     )
 

--- a/tests/unit/spark/test_spark_job_input_generation.py
+++ b/tests/unit/spark/test_spark_job_input_generation.py
@@ -43,7 +43,6 @@ async def test_spark_job_values_generation(setup_clients):
             ),
             image=ContainerImage(repository="myrepo/spark-job", tag="v1.2.3"),
             spark_auto_scaling_config=SparkAutoScalingConfig(
-                enabled=True,
                 initial_executors=2,
                 min_executors=1,
                 max_executors=5,


### PR DESCRIPTION
This pull request introduces several updates to improve configuration flexibility, enhance schema metadata, and simplify default values in Spark and MLFlow-related components. The most notable changes include the removal of the `enabled` field for Spark auto-scaling, the introduction of `_SPARK_DEFAULT_IMAGE` for default container images, and the addition of detailed schema metadata for various configurations.

### Spark-related changes:

* Removed the `enabled` field from `SparkAutoScalingConfig`, simplifying the auto-scaling configuration. The `enabled` property is now implicitly set to `True` in `add_autoscaling_config`. [[1]](diffhunk://#diff-bbe06052ddde6b5cc81e3fe1720235d987b2bee996adb5e1c4ec7330d6ccd3b3L128-R128) [[2]](diffhunk://#diff-ae68b345bd34a7fd518bfcf5106a6e83c8c8f15465518d34a76ceb28b723a0bcL140-L147) [[3]](diffhunk://#diff-eaaad75778f4ccc50827bc1ed441900f67a5be71a34d23de4254ed4ac19aed00L46)
* Introduced `_SPARK_DEFAULT_IMAGE` as a centralized default value for Spark container images. Updated the `SparkJobInputs` class to use this constant, improving maintainability. [[1]](diffhunk://#diff-ae68b345bd34a7fd518bfcf5106a6e83c8c8f15465518d34a76ceb28b723a0bcR17-R19) [[2]](diffhunk://#diff-ae68b345bd34a7fd518bfcf5106a6e83c8c8f15465518d34a76ceb28b723a0bcL251-L259) [[3]](diffhunk://#diff-ae68b345bd34a7fd518bfcf5106a6e83c8c8f15465518d34a76ceb28b723a0bcR287-R305)
* Enhanced schema metadata for `DriverConfig`, `ExecutorConfig`, and `SparkApplicationConfig` to provide better descriptions and support advanced field annotations. [[1]](diffhunk://#diff-ae68b345bd34a7fd518bfcf5106a6e83c8c8f15465518d34a76ceb28b723a0bcR28-R34) [[2]](diffhunk://#diff-ae68b345bd34a7fd518bfcf5106a6e83c8c8f15465518d34a76ceb28b723a0bcR45-R53) [[3]](diffhunk://#diff-ae68b345bd34a7fd518bfcf5106a6e83c8c8f15465518d34a76ceb28b723a0bcR197-R203) [[4]](diffhunk://#diff-ae68b345bd34a7fd518bfcf5106a6e83c8c8f15465518d34a76ceb28b723a0bcR315)

### MLFlow-related changes:

* Replaced plain attributes in `MLFlowAppOutputs` with `Field` definitions that include detailed schema metadata, improving clarity and documentation for internal and external URLs.