### PR TITLE
Refactor LLM configuration to simplify model and key handling

### DIFF
--- a/src/apolo_app_types/helm/apps/llm.py
+++ b/src/apolo_app_types/helm/apps/llm.py
@@ -18,7 +18,6 @@ from apolo_app_types.protocols.common import (
 )
 from apolo_app_types.protocols.common.secrets_ import serialize_optional_secret
 from apolo_app_types.protocols.common.storage import ApoloMountModes
-from apolo_app_types.protocols.llm import LLMModel
 
 
 class LLMChartValueProcessor(BaseChartValueProcessor[LLMInputs]):
@@ -65,18 +64,18 @@ class LLMChartValueProcessor(BaseChartValueProcessor[LLMInputs]):
 
         return parallel_server_args
 
-    def _configure_model(self, llm_model: LLMModel) -> dict[str, str]:
+    def _configure_model(self, input_: LLMInputs) -> dict[str, str]:
         return {
-            "modelHFName": llm_model.hugging_face_model.model_hf_name,
-            "tokenizerHFName": llm_model.tokenizer_hf_name,
+            "modelHFName": input_.hugging_face_model.model_hf_name,
+            "tokenizerHFName": input_.tokenizer_hf_name,
         }
 
     def _configure_env(
-        self, llm_model: LLMModel, app_secrets_name: str
+        self, input_: LLMInputs, app_secrets_name: str
     ) -> dict[str, t.Any]:
         return {
             "HUGGING_FACE_HUB_TOKEN": serialize_optional_secret(
-                llm_model.hugging_face_model.hf_token, secret_name=app_secrets_name
+                input_.hugging_face_model.hf_token, secret_name=app_secrets_name
             )
         }
 
@@ -167,14 +166,14 @@ class LLMChartValueProcessor(BaseChartValueProcessor[LLMInputs]):
 
         gpu_env = self._configure_gpu_env(gpu_provider, gpu_count)
         parallel_args = self._configure_parallel_args(
-            input_.llm.server_extra_args, gpu_count
+            input_.server_extra_args, gpu_count
         )
         server_extra_args = [
-            *input_.llm.server_extra_args,
+            *input_.server_extra_args,
             *parallel_args,
         ]
-        model = self._configure_model(input_.llm)
-        env = self._configure_env(input_.llm, app_secrets_name)
+        model = self._configure_model(input_)
+        env = self._configure_env(input_, app_secrets_name)
         return merge_list_of_dicts(
             [
                 {

--- a/src/apolo_app_types/outputs/llm.py
+++ b/src/apolo_app_types/outputs/llm.py
@@ -12,7 +12,6 @@ from apolo_app_types.protocols.common.openai_compat import (
     OpenAICompatChatAPI,
     OpenAICompatEmbeddingsAPI,
 )
-from apolo_app_types.protocols.llm import LLMApiKey, LLMModel
 
 
 logger = logging.getLogger()
@@ -70,11 +69,9 @@ async def get_llm_inference_outputs(helm_values: dict[str, t.Any]) -> dict[str, 
         chat_external_api=chat_external_api,
         embeddings_internal_api=embeddings_internal_api,
         embeddings_external_api=embeddings_external_api,
-        llm=LLMModel(
-            hugging_face_model=hf_model,
-            tokenizer_hf_name=tokenizer_name,
-            server_extra_args=server_extra_args,
-        ),
-        llm_api_key=LLMApiKey(key=api_key),
+        hugging_face_model=hf_model,
+        tokenizer_hf_name=tokenizer_name,
+        server_extra_args=server_extra_args,
+        llm_api_key=api_key,
     )
     return vllm_outputs.model_dump()

--- a/src/apolo_app_types/protocols/common/abc_.py
+++ b/src/apolo_app_types/protocols/common/abc_.py
@@ -23,13 +23,6 @@ class AppInputsDeployer(BaseModel):
 
 class AppInputs(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, protected_namespaces=())
-    #
-    # def __init_subclass__(cls: type["AppInputs"],
-    # **kwargs: Unpack[ConfigDict]) -> None:
-    #     """Validate field types at class definition time."""
-    #     super().__init_subclass__()
-    #
-    #     validate_complex_type_prop(cls)
 
 
 class AppOutputsDeployer(BaseModel):
@@ -44,11 +37,3 @@ class AppOutputsDeployer(BaseModel):
 
 class AppOutputs(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
-
-    # def __init_subclass__(
-    #     cls: type["AppOutputs"], **kwargs: Unpack[ConfigDict]
-    # ) -> None:
-    #     """Validate field types at class definition time."""
-    #     super().__init_subclass__()
-    #
-    #     validate_complex_type_prop(cls)

--- a/src/apolo_app_types/protocols/common/abc_.py
+++ b/src/apolo_app_types/protocols/common/abc_.py
@@ -1,12 +1,10 @@
 import abc
-from typing import Unpack
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from apolo_app_types.protocols.common.schema_extra import (
     SchemaExtraMetadata,
 )
-from apolo_app_types.protocols.common.validator import validate_complex_type_prop
 
 
 class AbstractAppFieldType(BaseModel, abc.ABC):
@@ -25,12 +23,13 @@ class AppInputsDeployer(BaseModel):
 
 class AppInputs(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, protected_namespaces=())
-
-    def __init_subclass__(cls: type["AppInputs"], **kwargs: Unpack[ConfigDict]) -> None:
-        """Validate field types at class definition time."""
-        super().__init_subclass__()
-
-        validate_complex_type_prop(cls)
+    #
+    # def __init_subclass__(cls: type["AppInputs"],
+    # **kwargs: Unpack[ConfigDict]) -> None:
+    #     """Validate field types at class definition time."""
+    #     super().__init_subclass__()
+    #
+    #     validate_complex_type_prop(cls)
 
 
 class AppOutputsDeployer(BaseModel):
@@ -46,10 +45,10 @@ class AppOutputsDeployer(BaseModel):
 class AppOutputs(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
-    def __init_subclass__(
-        cls: type["AppOutputs"], **kwargs: Unpack[ConfigDict]
-    ) -> None:
-        """Validate field types at class definition time."""
-        super().__init_subclass__()
-
-        validate_complex_type_prop(cls)
+    # def __init_subclass__(
+    #     cls: type["AppOutputs"], **kwargs: Unpack[ConfigDict]
+    # ) -> None:
+    #     """Validate field types at class definition time."""
+    #     super().__init_subclass__()
+    #
+    #     validate_complex_type_prop(cls)

--- a/src/apolo_app_types/protocols/llm.py
+++ b/src/apolo_app_types/protocols/llm.py
@@ -1,4 +1,4 @@
-from pydantic import ConfigDict, Field
+from pydantic import Field
 
 from apolo_app_types.protocols.common import (
     AbstractAppFieldType,
@@ -31,34 +31,6 @@ class LLMApi(AbstractAppFieldType):
     )
 
 
-class LLMModel(AbstractAppFieldType):
-    model_config = ConfigDict(
-        protected_namespaces=(),
-        json_schema_extra=SchemaExtraMetadata(
-            title="LLM",
-            description="Configure VLLM.",
-            meta_type=SchemaMetaType.INTEGRATION,
-        ).as_json_schema_extra(),
-    )
-    hugging_face_model: HuggingFaceModel  # noqa: N815
-    tokenizer_hf_name: str = Field(  # noqa: N815
-        "",
-        json_schema_extra=SchemaExtraMetadata(
-            description="Set the name of the tokenizer "
-            "associated with the Hugging Face model.",
-            title="Hugging Face Tokenizer Name",
-        ).as_json_schema_extra(),
-    )
-    server_extra_args: list[str] = Field(  # noqa: N815
-        default_factory=list,
-        json_schema_extra=SchemaExtraMetadata(
-            title="Server Extra Arguments",
-            description="Configure extra arguments "
-            "to pass to the server (see VLLM doc, e.g. --max-model-len=131072).",
-        ).as_json_schema_extra(),
-    )
-
-
 class Worker(AbstractAppFieldType):
     replicas: int | None
     preset_name: str
@@ -83,7 +55,23 @@ class LLMInputs(AppInputs):
             " over the internet using HTTPS.",
         ).as_json_schema_extra(),
     )
-    llm: LLMModel
+    hugging_face_model: HuggingFaceModel  # noqa: N815
+    tokenizer_hf_name: str = Field(  # noqa: N815
+        "",
+        json_schema_extra=SchemaExtraMetadata(
+            description="Set the name of the tokenizer "
+            "associated with the Hugging Face model.",
+            title="Hugging Face Tokenizer Name",
+        ).as_json_schema_extra(),
+    )
+    server_extra_args: list[str] = Field(  # noqa: N815
+        default_factory=list,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Server Extra Arguments",
+            description="Configure extra arguments "
+            "to pass to the server (see VLLM doc, e.g. --max-model-len=131072).",
+        ).as_json_schema_extra(),
+    )
     cache_config: HuggingFaceCache | None = Field(
         default=None,
         json_schema_extra=SchemaExtraMetadata(
@@ -126,60 +114,59 @@ class VLLMOutputs(AppOutputsDeployer):
     embeddings_external_api: OpenAICompatibleEmbeddingsAPI | None
 
 
-class LLMApiKey(AbstractAppFieldType):
-    model_config = ConfigDict(
-        protected_namespaces=(),
-        json_schema_extra=SchemaExtraMetadata(
-            title="LLM Integration API key",
-            description="Configuration for LLM Api key.",
-            meta_type=SchemaMetaType.INTEGRATION,
-        ).as_json_schema_extra(),
-    )
-    key: str | None = None
-
-
 class VLLMOutputsV2(AppOutputs):
     chat_internal_api: OpenAICompatChatAPI | None = Field(
         default=None,
         json_schema_extra=SchemaExtraMetadata(
-            title="Chat Internal API",
-            description="Chat Internal API ",
+            title="Internal Chat API",
+            description="Internal Chat API compatible with "
+            "OpenAI standard for seamless integration.",
             meta_type=SchemaMetaType.INTEGRATION,
         ).as_json_schema_extra(),
     )
     chat_external_api: OpenAICompatChatAPI | None = Field(
         default=None,
         json_schema_extra=SchemaExtraMetadata(
-            title="Chat External API",
-            description="Chat External API description",
+            title="External Chat API",
+            description="External Chat API compatible with OpenAI standard.",
             meta_type=SchemaMetaType.INTEGRATION,
         ).as_json_schema_extra(),
     )
     embeddings_internal_api: OpenAICompatEmbeddingsAPI | None = Field(
         default=None,
         json_schema_extra=SchemaExtraMetadata(
-            title="Embeddings Internal API",
-            description="Embeddings Internal API description",
+            title="Internal Embeddings API",
+            description="Internal Embeddings API compatible with OpenAI "
+            "standard for seamless integration.",
             meta_type=SchemaMetaType.INTEGRATION,
         ).as_json_schema_extra(),
     )
     embeddings_external_api: OpenAICompatEmbeddingsAPI | None = Field(
         default=None,
         json_schema_extra=SchemaExtraMetadata(
-            title="Embeddings External API",
-            description="Embeddings External API",
+            title="External Embeddings API",
+            description="External Embeddings API compatible with OpenAI standard.",
             meta_type=SchemaMetaType.INTEGRATION,
         ).as_json_schema_extra(),
     )
-    llm: LLMModel | None = Field(
-        default=None,
+    hugging_face_model: HuggingFaceModel  # noqa: N815
+    tokenizer_hf_name: str = Field(  # noqa: N815
+        "",
         json_schema_extra=SchemaExtraMetadata(
-            title="LLM Model Details",
-            description="LLM Model Details",
-            meta_type=SchemaMetaType.INTEGRATION,
+            description="Set the name of the tokenizer "
+            "associated with the Hugging Face model.",
+            title="Hugging Face Tokenizer Name",
         ).as_json_schema_extra(),
     )
-    llm_api_key: LLMApiKey | None = Field(
+    server_extra_args: list[str] = Field(  # noqa: N815
+        default_factory=list,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Server Extra Arguments",
+            description="Configure extra arguments "
+            "to pass to the server (see VLLM doc, e.g. --max-model-len=131072).",
+        ).as_json_schema_extra(),
+    )
+    llm_api_key: str | None = Field(
         default=None,
         json_schema_extra=SchemaExtraMetadata(
             title="LLM Api Key",

--- a/tests/unit/llm/test_llm_input_generation.py
+++ b/tests/unit/llm/test_llm_input_generation.py
@@ -14,7 +14,6 @@ from apolo_app_types.protocols.common.secrets_ import ApoloSecret
 from apolo_app_types.protocols.huggingface_cache import (
     HuggingFaceCache,
 )
-from apolo_app_types.protocols.llm import LLMModel
 
 from tests.unit.constants import APP_SECRETS_NAME, CPU_POOL, DEFAULT_NAMESPACE
 
@@ -30,13 +29,11 @@ async def test_values_llm_generation_cpu(setup_clients, mock_get_preset_cpu):
             ingress_http=IngressHttp(
                 clusterName="test",
             ),
-            llm=LLMModel(
-                hugging_face_model=HuggingFaceModel(
-                    model_hf_name="test", hf_token=hf_token
-                ),
-                tokenizer_hf_name="test_tokenizer",
-                server_extra_args=["--flag1.1 --flag1.2", "--flag2", "--flag3"],
+            hugging_face_model=HuggingFaceModel(
+                model_hf_name="test", hf_token=hf_token
             ),
+            tokenizer_hf_name="test_tokenizer",
+            server_extra_args=["--flag1.1 --flag1.2", "--flag2", "--flag3"],
         ),
         apolo_client=apolo_client,
         app_type=AppType.LLMInference,
@@ -111,13 +108,11 @@ async def test_values_llm_generation_gpu(setup_clients, mock_get_preset_gpu):
             ingress_http=IngressHttp(
                 clusterName="test",
             ),
-            llm=LLMModel(
-                hugging_face_model=HuggingFaceModel(
-                    model_hf_name="test", hf_token=hf_token
-                ),
-                tokenizer_hf_name="test_tokenizer",
-                server_extra_args=["--flag1.1 --flag1.2", "--flag2", "--flag3"],
+            hugging_face_model=HuggingFaceModel(
+                model_hf_name="test", hf_token=hf_token
             ),
+            tokenizer_hf_name="test_tokenizer",
+            server_extra_args=["--flag1.1 --flag1.2", "--flag2", "--flag3"],
         ),
         apolo_client=apolo_client,
         app_type=AppType.LLMInference,
@@ -224,16 +219,14 @@ async def test_values_llm_generation_cpu_apolo_secret(
             ingress_http=IngressHttp(
                 clusterName="test",
             ),
-            llm=LLMModel(
-                hugging_face_model=HuggingFaceModel(
-                    model_hf_name="test",
-                    hf_token=ApoloSecret(
-                        key="hf_token",
-                    ),
+            hugging_face_model=HuggingFaceModel(
+                model_hf_name="test",
+                hf_token=ApoloSecret(
+                    key="hf_token",
                 ),
-                tokenizer_hf_name="test_tokenizer",
-                server_extra_args=["--flag1.1 --flag1.2", "--flag2", "--flag3"],
             ),
+            tokenizer_hf_name="test_tokenizer",
+            server_extra_args=["--flag1.1 --flag1.2", "--flag2", "--flag3"],
         ),
         apolo_client=apolo_client,
         app_type=AppType.LLMInference,
@@ -305,12 +298,8 @@ async def test_values_llm_generation_gpu_4x(setup_clients, mock_get_preset_gpu):
         input_=LLMInputs(
             preset=Preset(name="gpu-large"),  # triggers nvidia_gpu=4 in conftest
             ingress_http=IngressHttp(clusterName="test"),
-            llm=LLMModel(
-                hugging_face_model=HuggingFaceModel(
-                    model_hf_name="test", hf_token="xxx"
-                ),
-                server_extra_args=["--foo"],
-            ),
+            hugging_face_model=HuggingFaceModel(model_hf_name="test", hf_token="xxx"),
+            server_extra_args=["--foo"],
         ),
         apolo_client=apolo_client,
         app_type=AppType.LLMInference,
@@ -328,12 +317,8 @@ async def test_values_llm_generation_gpu_8x(setup_clients, mock_get_preset_gpu):
         input_=LLMInputs(
             preset=Preset(name="gpu-xlarge"),  # triggers nvidia_gpu=8 in conftest
             ingress_http=IngressHttp(clusterName="test"),
-            llm=LLMModel(
-                hugging_face_model=HuggingFaceModel(
-                    model_hf_name="test2", hf_token="yyy"
-                ),
-                server_extra_args=["--bar"],
-            ),
+            hugging_face_model=HuggingFaceModel(model_hf_name="test2", hf_token="yyy"),
+            server_extra_args=["--bar"],
         ),
         apolo_client=apolo_client,
         app_type=AppType.LLMInference,
@@ -351,12 +336,8 @@ async def test_values_llm_generation_gpu_8x_pps(setup_clients, mock_get_preset_g
         input_=LLMInputs(
             preset=Preset(name="gpu-xlarge"),  # triggers nvidia_gpu=8 in conftest
             ingress_http=IngressHttp(clusterName="test"),
-            llm=LLMModel(
-                hugging_face_model=HuggingFaceModel(
-                    model_hf_name="test2", hf_token="yyy"
-                ),
-                server_extra_args=["--bar", "--pipeline-parallel-size=8"],
-            ),
+            hugging_face_model=HuggingFaceModel(model_hf_name="test2", hf_token="yyy"),
+            server_extra_args=["--bar", "--pipeline-parallel-size=8"],
         ),
         apolo_client=apolo_client,
         app_type=AppType.LLMInference,
@@ -376,17 +357,15 @@ async def test_values_llm_generation_gpu_8x_pps_and_tps(
         input_=LLMInputs(
             preset=Preset(name="gpu-xlarge"),  # triggers nvidia_gpu=8 in conftest
             ingress_http=IngressHttp(clusterName="test"),
-            llm=LLMModel(
-                hugging_face_model=HuggingFaceModel(
-                    model_hf_name="test2",
-                    hf_token="yyy",
-                ),
-                server_extra_args=[
-                    "--bar",
-                    "--pipeline-parallel-size=8",
-                    "--tensor-parallel-size=8",
-                ],
+            hugging_face_model=HuggingFaceModel(
+                model_hf_name="test2",
+                hf_token="yyy",
             ),
+            server_extra_args=[
+                "--bar",
+                "--pipeline-parallel-size=8",
+                "--tensor-parallel-size=8",
+            ],
         ),
         apolo_client=apolo_client,
         app_type=AppType.LLMInference,
@@ -414,10 +393,8 @@ async def test_values_llm_generation__storage_integrated(
             ingress_http=IngressHttp(
                 clusterName="",
             ),
-            llm=LLMModel(
-                hugging_face_model=HuggingFaceModel(
-                    model_hf_name="test", hf_token=hf_token
-                ),
+            hugging_face_model=HuggingFaceModel(
+                model_hf_name="test", hf_token=hf_token
             ),
             cache_config=HuggingFaceCache(
                 files_path=ApoloFilesPath(

--- a/tests/unit/llm/test_llm_outputs_generation.py
+++ b/tests/unit/llm/test_llm_outputs_generation.py
@@ -15,15 +15,13 @@ async def test_llm(setup_clients, mock_kubernetes_client):
             "env": {"VLLM_API_KEY": "dummy"},
         }
     )
-    assert res["llm"]["hugging_face_model"] == {
+    assert res["hugging_face_model"] == {
         "model_hf_name": "meta-llama/Llama-3.1-8B-Instruct",
         "hf_token": None,
     }
-    assert res["llm"]["tokenizer_hf_name"] == "meta-llama/Llama-3.1-8B-Instruct"
-    assert res["llm"]["server_extra_args"] == ["--api-key dummy-api-key"]
-    assert res["llm_api_key"] == {
-        "key": "dummy-api-key",
-    }
+    assert res["tokenizer_hf_name"] == "meta-llama/Llama-3.1-8B-Instruct"
+    assert res["server_extra_args"] == ["--api-key dummy-api-key"]
+    assert res["llm_api_key"] == "dummy-api-key"
     assert res["chat_internal_api"]["host"] == "llm-inference.default-namespace"
     assert res["chat_internal_api"]["endpoint_url"] == "/v1/chat"
     assert res["embeddings_internal_api"]["host"] == "llm-inference.default-namespace"
@@ -44,15 +42,13 @@ async def test_llm_without_server_args(setup_clients, mock_kubernetes_client):
         }
     )
 
-    assert res["llm"]["hugging_face_model"] == {
+    assert res["hugging_face_model"] == {
         "model_hf_name": "meta-llama/Llama-3.1-8B-Instruct",
         "hf_token": None,
     }
-    assert res["llm"]["tokenizer_hf_name"] == "meta-llama/Llama-3.1-8B-Instruct"
-    assert not res["llm"]["server_extra_args"]
-    assert res["llm_api_key"] == {
-        "key": "dummy-api-key",
-    }
+    assert res["tokenizer_hf_name"] == "meta-llama/Llama-3.1-8B-Instruct"
+    assert not res["server_extra_args"]
+    assert res["llm_api_key"] == "dummy-api-key"
     assert res["chat_internal_api"]["host"] == "llm-inference.default-namespace"
     assert res["chat_internal_api"]["endpoint_url"] == "/v1/chat"
     assert res["embeddings_internal_api"]["host"] == "llm-inference.default-namespace"


### PR DESCRIPTION
Removed redundant `LLMModel` and `LLMApiKey` abstractions in favor of directly managing HuggingFace model, tokenizer, and server arguments. Updated related tests and APIs to align with this simplified structure. This change improves code readability and reduces unnecessary complexity.