### PR TITLE
Fix field title and descriptions

### DIFF
--- a/src/apolo_app_types/protocols/mlflow.py
+++ b/src/apolo_app_types/protocols/mlflow.py
@@ -46,6 +46,24 @@ class MLFlowMetadataSQLite(AbstractAppFieldType):
 MLFlowMetaStorage = MLFlowMetadataSQLite | MLFlowMetadataPostgres
 
 
+class MLFlowArtifactStore(ApoloFilesPath):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Artifact Store",
+            description=(
+                "Use Apolo Files to store your MLFlow artifacts "
+                "(model binaries, dependency files, etc). "
+                "E.g. 'storage://cluster/myorg/proj/mlflow-artifacts'"
+                "or relative path E.g. 'storage:mlflow-artifacts'"
+            ),
+        ).as_json_schema_extra(),
+    )
+    path: str = Field(
+        default="storage:mlflow-artifacts",
+    )
+
+
 class MLFlowAppInputs(AppInputs):
     """
     The overall MLFlow app config, referencing:
@@ -57,18 +75,7 @@ class MLFlowAppInputs(AppInputs):
     preset: Preset
     ingress_http: IngressHttp
     metadata_storage: MLFlowMetaStorage
-    artifact_store: ApoloFilesPath = Field(
-        default=ApoloFilesPath(path="storage:mlflow-artifacts"),
-        json_schema_extra=SchemaExtraMetadata(
-            description=(
-                "Use Apolo Files to store your MLFlow artifacts "
-                "(model binaries, dependency files, etc). "
-                "E.g. 'storage://cluster/myorg/proj/mlflow-artifacts'"
-                "or relative path E.g. 'storage:mlflow-artifacts'"
-            ),
-            title="Artifact Store",
-        ).as_json_schema_extra(),
-    )
+    artifact_store: MLFlowArtifactStore
 
 
 class MLFlowAppOutputs(AppOutputs):

--- a/tests/unit/mlflow/test_mlflow_input_generation.py
+++ b/tests/unit/mlflow/test_mlflow_input_generation.py
@@ -3,12 +3,12 @@ import pytest
 from apolo_app_types.app_types import AppType
 from apolo_app_types.inputs.args import app_type_to_vals
 from apolo_app_types.protocols.common import (
-    ApoloFilesPath,
     IngressHttp,
     Preset,
 )
 from apolo_app_types.protocols.mlflow import (
     MLFlowAppInputs,
+    MLFlowArtifactStore,
     MLFlowMetadataPostgres,
     MLFlowMetadataSQLite,
     PostgresURI,
@@ -29,7 +29,7 @@ async def test_values_mlflow_generation_default_sqlite(
         preset=Preset(name="cpu-small"),
         ingress_http=IngressHttp(clusterName="test"),
         metadata_storage=MLFlowMetadataSQLite(),
-        artifact_store=ApoloFilesPath(
+        artifact_store=MLFlowArtifactStore(
             path="storage://test-cluster/myorg/proj/mlflow-artifacts"
         ),
     )
@@ -89,7 +89,7 @@ async def test_values_mlflow_generation_sqlite_explicit_no_pvc_name(
         preset=Preset(name="cpu-small"),
         ingress_http=IngressHttp(clusterName="test"),
         metadata_storage=MLFlowMetadataSQLite(),
-        artifact_store=ApoloFilesPath(path="storage://foo/bar/baz"),
+        artifact_store=MLFlowArtifactStore(path="storage://foo/bar/baz"),
     )
 
     helm_args, helm_params = await app_type_to_vals(
@@ -128,7 +128,7 @@ async def test_values_mlflow_generation_sqlite_explicit_custom_pvc_name(
         preset=Preset(name="cpu-small"),
         ingress_http=IngressHttp(clusterName="test"),
         metadata_storage=MLFlowMetadataSQLite(pvc_name=custom_pvc_name),
-        artifact_store=ApoloFilesPath(path="storage://foo/bar/baz"),
+        artifact_store=MLFlowArtifactStore(path="storage://foo/bar/baz"),
     )
 
     helm_args, helm_params = await app_type_to_vals(
@@ -170,7 +170,7 @@ async def test_values_mlflow_generation_postgres_uri(
                 uri="postgresql://user:pass@custom-host:5432/mlflow"
             ),
         ),
-        artifact_store=ApoloFilesPath(
+        artifact_store=MLFlowArtifactStore(
             path="storage://test-cluster/myorg/proj/mlflow-artifacts"
         ),
     )


### PR DESCRIPTION
Previous input schema 

```
{
            "$defs": {
                "ApoloFilesPath": {
                    "properties": {
                        "path": {
                            "title": "Path",
                            "type": "string",
                            "x-description": "Provide the Apolo Storage path starting with `storage:` to locate your files.",
                            "x-is-advanced-field": false,
                            "x-meta-type": "inline",
                            "x-title": "Storage Path"
                        }
                    },
                    "required": [
                        "path"
                    ],
                    "title": "ApoloFilesPath",
                    "type": "object",
                    "x-description": "Specify the path within the Apolo Files application to read from or write to.",
                    "x-is-advanced-field": false,
                    "x-meta-type": "inline",
                    "x-title": "Apolo Files Path"
                },
                "IngressHttp": {
                    "properties": {
                        "auth": {
                            "default": true,
                            "title": "Auth",
                            "type": "boolean",
                            "x-description": "Require authenticated user credentials with appropriate permissions for all incoming HTTPS requests to the application.",
                            "x-is-advanced-field": false,
                            "x-meta-type": "inline",
                            "x-title": "Enable Authentication and Authorization"
                        }
                    },
                    "title": "IngressHttp",
                    "type": "object",
                    "x-description": "Enable access to your application over the internet using HTTPS.",
                    "x-is-advanced-field": false,
                    "x-meta-type": "inline",
                    "x-title": "Enable HTTP Ingress"
                },
                "MLFlowMetadataPostgres": {
                    "properties": {
                        "postgres_uri": {
                            "$ref": "#/$defs/PostgresURI"
                        }
                    },
                    "required": [
                        "postgres_uri"
                    ],
                    "title": "MLFlowMetadataPostgres",
                    "type": "object",
                    "x-description": "Use PostgreSQL server as metadata storage for MLFlow.",
                    "x-is-advanced-field": false,
                    "x-meta-type": "inline",
                    "x-title": "Postgres"
                },
                "MLFlowMetadataSQLite": {
                    "properties": {
                        "pvc_name": {
                            "default": "mlflow-sqlite-storage",
                            "title": "Pvc Name",
                            "type": "string",
                            "x-description": "Specify the name of the PVC claim to store local DB.",
                            "x-is-advanced-field": false,
                            "x-meta-type": "inline",
                            "x-title": "PVC Name"
                        }
                    },
                    "title": "MLFlowMetadataSQLite",
                    "type": "object",
                    "x-description": "Use SQLite on a dedicated block device as metadata store for MLFlow.",
                    "x-is-advanced-field": false,
                    "x-meta-type": "inline",
                    "x-title": "SQLite"
                },
                "PostgresURI": {
                    "description": "Configuration for the Postgres connection URI.",
                    "properties": {
                        "uri": {
                            "anyOf": [
                                {
                                    "type": "string"
                                },
                                {
                                    "type": "null"
                                }
                            ],
                            "default": null,
                            "title": "Uri",
                            "x-description": "Specify full Postgres connection URI. E.g. 'postgresql://user:pass@host:5432/db'",
                            "x-is-advanced-field": false,
                            "x-meta-type": "inline",
                            "x-title": "URI"
                        }
                    },
                    "title": "PostgresURI",
                    "type": "object",
                    "x-description": "Full Postgres connection URI configuration.",
                    "x-is-advanced-field": false,
                    "x-meta-type": "inline",
                    "x-title": "Postgres URI"
                },
                "Preset": {
                    "properties": {
                        "name": {
                            "description": "The name of the preset.",
                            "title": "Preset name",
                            "type": "string"
                        }
                    },
                    "required": [
                        "name"
                    ],
                    "title": "Preset",
                    "type": "object",
                    "x-description": "Select the resource preset used per service replica.",
                    "x-is-advanced-field": false,
                    "x-meta-type": "integration",
                    "x-title": "Resource Preset"
                }
            },
            "description": "The overall MLFlow app config, referencing:\n  - 'preset' for CPU/GPU resources\n  - 'ingress' for external URL\n  - 'mlflow_specific' for MLFlow settings",
            "properties": {
                "preset": {
                    "$ref": "#/$defs/Preset"
                },
                "ingress_http": {
                    "$ref": "#/$defs/IngressHttp"
                },
                "metadata_storage": {
                    "anyOf": [
                        {
                            "$ref": "#/$defs/MLFlowMetadataSQLite"
                        },
                        {
                            "$ref": "#/$defs/MLFlowMetadataPostgres"
                        }
                    ],
                    "title": "Metadata Storage"
                },
                "artifact_store": {
                    "$ref": "#/$defs/ApoloFilesPath",
                    "default": {
                        "path": "storage:mlflow-artifacts"
                    },
                    "x-description": "Use Apolo Files to store your MLFlow artifacts (model binaries, dependency files, etc). E.g. 'storage://cluster/myorg/proj/mlflow-artifacts'or relative path E.g. 'storage:mlflow-artifacts'",
                    "x-title": "Artifact Store"
                }
            },
            "required": [
                "preset",
                "ingress_http",
                "metadata_storage"
            ],
            "title": "MLFlowAppInputs",
            "type": "object"
        }
```

new input schema

```
{
            "$defs": {
                "IngressHttp": {
                    "properties": {
                        "auth": {
                            "default": true,
                            "title": "Auth",
                            "type": "boolean",
                            "x-description": "Require authenticated user credentials with appropriate permissions for all incoming HTTPS requests to the application.",
                            "x-is-advanced-field": false,
                            "x-meta-type": "inline",
                            "x-title": "Enable Authentication and Authorization"
                        }
                    },
                    "title": "IngressHttp",
                    "type": "object",
                    "x-description": "Enable access to your application over the internet using HTTPS.",
                    "x-is-advanced-field": false,
                    "x-meta-type": "inline",
                    "x-title": "Enable HTTP Ingress"
                },
                "MLFlowArtifactStore": {
                    "properties": {
                        "path": {
                            "default": "storage:mlflow-artifacts",
                            "title": "Path",
                            "type": "string"
                        }
                    },
                    "title": "MLFlowArtifactStore",
                    "type": "object",
                    "x-description": "Use Apolo Files to store your MLFlow artifacts (model binaries, dependency files, etc). E.g. 'storage://cluster/myorg/proj/mlflow-artifacts'or relative path E.g. 'storage:mlflow-artifacts'",
                    "x-is-advanced-field": false,
                    "x-meta-type": "inline",
                    "x-title": "Artifact Store"
                },
                "MLFlowMetadataPostgres": {
                    "properties": {
                        "postgres_uri": {
                            "$ref": "#/$defs/PostgresURI"
                        }
                    },
                    "required": [
                        "postgres_uri"
                    ],
                    "title": "MLFlowMetadataPostgres",
                    "type": "object",
                    "x-description": "Use PostgreSQL server as metadata storage for MLFlow.",
                    "x-is-advanced-field": false,
                    "x-meta-type": "inline",
                    "x-title": "Postgres"
                },
                "MLFlowMetadataSQLite": {
                    "properties": {
                        "pvc_name": {
                            "default": "mlflow-sqlite-storage",
                            "title": "Pvc Name",
                            "type": "string",
                            "x-description": "Specify the name of the PVC claim to store local DB.",
                            "x-is-advanced-field": false,
                            "x-meta-type": "inline",
                            "x-title": "PVC Name"
                        }
                    },
                    "title": "MLFlowMetadataSQLite",
                    "type": "object",
                    "x-description": "Use SQLite on a dedicated block device as metadata store for MLFlow.",
                    "x-is-advanced-field": false,
                    "x-meta-type": "inline",
                    "x-title": "SQLite"
                },
                "PostgresURI": {
                    "description": "Configuration for the Postgres connection URI.",
                    "properties": {
                        "uri": {
                            "anyOf": [
                                {
                                    "type": "string"
                                },
                                {
                                    "type": "null"
                                }
                            ],
                            "default": null,
                            "title": "Uri",
                            "x-description": "Specify full Postgres connection URI. E.g. 'postgresql://user:pass@host:5432/db'",
                            "x-is-advanced-field": false,
                            "x-meta-type": "inline",
                            "x-title": "URI"
                        }
                    },
                    "title": "PostgresURI",
                    "type": "object",
                    "x-description": "Full Postgres connection URI configuration.",
                    "x-is-advanced-field": false,
                    "x-meta-type": "inline",
                    "x-title": "Postgres URI"
                },
                "Preset": {
                    "properties": {
                        "name": {
                            "description": "The name of the preset.",
                            "title": "Preset name",
                            "type": "string"
                        }
                    },
                    "required": [
                        "name"
                    ],
                    "title": "Preset",
                    "type": "object",
                    "x-description": "Select the resource preset used per service replica.",
                    "x-is-advanced-field": false,
                    "x-meta-type": "integration",
                    "x-title": "Resource Preset"
                }
            },
            "description": "The overall MLFlow app config, referencing:\n  - 'preset' for CPU/GPU resources\n  - 'ingress' for external URL\n  - 'mlflow_specific' for MLFlow settings",
            "properties": {
                "preset": {
                    "$ref": "#/$defs/Preset"
                },
                "ingress_http": {
                    "$ref": "#/$defs/IngressHttp"
                },
                "metadata_storage": {
                    "anyOf": [
                        {
                            "$ref": "#/$defs/MLFlowMetadataSQLite"
                        },
                        {
                            "$ref": "#/$defs/MLFlowMetadataPostgres"
                        }
                    ],
                    "title": "Metadata Storage"
                },
                "artifact_store": {
                    "$ref": "#/$defs/MLFlowArtifactStore"
                }
            },
            "required": [
                "preset",
                "ingress_http",
                "metadata_storage",
                "artifact_store"
            ],
            "title": "MLFlowAppInputs",
            "type": "object"
        }
```