### PR TITLE
Add support Health checks customization in Custom Deployment

### DIFF
--- a/src/apolo_app_types/helm/apps/custom_deployment.py
+++ b/src/apolo_app_types/helm/apps/custom_deployment.py
@@ -11,7 +11,7 @@ from apolo_app_types.helm.utils.images import (
     get_apolo_registry_secrets_value,
     get_image_docker_url,
 )
-from apolo_app_types.helm.utils.pods import get_health_check_values
+from apolo_app_types.helm.utils.pods import get_custom_deployment_health_check_values
 
 
 class CustomDeploymentChartValueProcessor(
@@ -58,6 +58,8 @@ class CustomDeploymentChartValueProcessor(
         """
         Generate extra Helm values for Custom Deployment.
         """
+        health_checks = get_custom_deployment_health_check_values(input_.health_checks)
+
         extra_values = await gen_extra_values(
             apolo_client=self.client,
             preset_type=input_.preset,
@@ -133,7 +135,7 @@ class CustomDeploymentChartValueProcessor(
         if dockerconfig:
             values["dockerconfigjson"] = dockerconfig.filecontents
 
-        health_checks = get_health_check_values(input_.health_checks)
+        health_checks = get_custom_deployment_health_check_values(input_.health_checks)
         values |= health_checks
 
         return values

--- a/src/apolo_app_types/helm/apps/custom_deployment.py
+++ b/src/apolo_app_types/helm/apps/custom_deployment.py
@@ -11,6 +11,7 @@ from apolo_app_types.helm.utils.images import (
     get_apolo_registry_secrets_value,
     get_image_docker_url,
 )
+from apolo_app_types.helm.utils.pods import get_health_check_values
 
 
 class CustomDeploymentChartValueProcessor(
@@ -131,4 +132,8 @@ class CustomDeploymentChartValueProcessor(
 
         if dockerconfig:
             values["dockerconfigjson"] = dockerconfig.filecontents
+
+        health_checks = get_health_check_values(input_.health_checks)
+        values |= health_checks
+
         return values

--- a/src/apolo_app_types/helm/apps/fooocus.py
+++ b/src/apolo_app_types/helm/apps/fooocus.py
@@ -32,14 +32,13 @@ from apolo_app_types.protocols.custom_deployment import NetworkingConfig
 
 
 class FooocusChartValueProcessor(BaseChartValueProcessor[FooocusAppInputs]):
+    _port = 7865
+
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
         self.custom_dep_val_processor = CustomDeploymentChartValueProcessor(
             *args, **kwargs
         )
-
-    async def gen_extra_helm_args(self, *_: t.Any) -> list[str]:
-        return ["--timeout", "30m"]
 
     async def _configure_env(
         self, data_volume: URL, outputs_volume: URL
@@ -102,7 +101,7 @@ class FooocusChartValueProcessor(BaseChartValueProcessor[FooocusAppInputs]):
                 service_enabled=True,
                 ingress_http=input_.ingress_http,
                 ports=[
-                    Port(name="http", port=7865),
+                    Port(name="http", port=self._port),
                 ],
             ),
             storage_mounts=StorageMounts(
@@ -125,25 +124,23 @@ class FooocusChartValueProcessor(BaseChartValueProcessor[FooocusAppInputs]):
             ),
             health_checks=HealthCheckProbesConfig(
                 liveness=HealthCheck(
-                    enabled=True,
-                    port=7865,
-                    initial_delay_seconds=30,
+                    initial_delay=30,
                     period_seconds=5,
                     timeout=5,
                     failure_threshold=20,
                     health_check_config=HTTPHealthCheckConfig(
                         path="/",
+                        port=self._port,
                     ),
                 ),
                 readiness=HealthCheck(
-                    enabled=True,
-                    port=7865,
-                    initial_delay_seconds=30,
+                    initial_delay=30,
                     period_seconds=5,
                     timeout=5,
                     failure_threshold=20,
                     health_check_config=HTTPHealthCheckConfig(
                         path="/",
+                        port=self._port,
                     ),
                 ),
             ),

--- a/src/apolo_app_types/helm/apps/fooocus.py
+++ b/src/apolo_app_types/helm/apps/fooocus.py
@@ -22,6 +22,11 @@ from apolo_app_types.protocols.common import (
     MountPath,
     StorageMounts,
 )
+from apolo_app_types.protocols.common.health_check import (
+    HealthCheck,
+    HealthCheckProbesConfig,
+    HTTPHealthCheckConfig,
+)
 from apolo_app_types.protocols.common.k8s import Port
 from apolo_app_types.protocols.custom_deployment import NetworkingConfig
 
@@ -117,6 +122,30 @@ class FooocusChartValueProcessor(BaseChartValueProcessor[FooocusAppInputs]):
                         mode=ApoloMountMode(mode="rw"),
                     ),
                 ]
+            ),
+            health_checks=HealthCheckProbesConfig(
+                liveness=HealthCheck(
+                    enabled=True,
+                    port=7865,
+                    initial_delay_seconds=30,
+                    period_seconds=5,
+                    timeout=5,
+                    failure_threshold=20,
+                    health_check_config=HTTPHealthCheckConfig(
+                        path="/",
+                    ),
+                ),
+                readiness=HealthCheck(
+                    enabled=True,
+                    port=7865,
+                    initial_delay_seconds=30,
+                    period_seconds=5,
+                    timeout=5,
+                    failure_threshold=20,
+                    health_check_config=HTTPHealthCheckConfig(
+                        path="/",
+                    ),
+                ),
             ),
         )
 

--- a/src/apolo_app_types/helm/apps/jupyter.py
+++ b/src/apolo_app_types/helm/apps/jupyter.py
@@ -106,24 +106,24 @@ class JupyterChartValueProcessor(BaseChartValueProcessor[JupyterAppInputs]):
             health_checks=HealthCheckProbesConfig(
                 liveness=HealthCheck(
                     enabled=True,
-                    port=self._jupyter_port,
-                    initial_delay_seconds=30,
+                    initial_delay=30,
                     period_seconds=5,
                     timeout=5,
                     failure_threshold=20,
                     health_check_config=HTTPHealthCheckConfig(
                         path="/",
+                        port=self._jupyter_port,
                     ),
                 ),
                 readiness=HealthCheck(
                     enabled=True,
-                    port=self._jupyter_port,
-                    initial_delay_seconds=30,
+                    initial_delay=30,
                     period_seconds=5,
                     timeout=5,
                     failure_threshold=20,
                     health_check_config=HTTPHealthCheckConfig(
                         path="/",
+                        port=self._jupyter_port,
                     ),
                 ),
             ),

--- a/src/apolo_app_types/helm/apps/jupyter.py
+++ b/src/apolo_app_types/helm/apps/jupyter.py
@@ -11,6 +11,11 @@ from apolo_app_types.helm.apps.custom_deployment import (
     CustomDeploymentChartValueProcessor,
 )
 from apolo_app_types.protocols.common import Container, Env, StorageMounts
+from apolo_app_types.protocols.common.health_check import (
+    HealthCheck,
+    HealthCheckProbesConfig,
+    HTTPHealthCheckConfig,
+)
 from apolo_app_types.protocols.common.ingress import IngressHttp
 from apolo_app_types.protocols.common.k8s import Port
 from apolo_app_types.protocols.custom_deployment import NetworkingConfig
@@ -98,6 +103,30 @@ class JupyterChartValueProcessor(BaseChartValueProcessor[JupyterAppInputs]):
                 ],
             ),
             storage_mounts=storage_mounts,
+            health_checks=HealthCheckProbesConfig(
+                liveness=HealthCheck(
+                    enabled=True,
+                    port=self._jupyter_port,
+                    initial_delay_seconds=30,
+                    period_seconds=5,
+                    timeout=5,
+                    failure_threshold=20,
+                    health_check_config=HTTPHealthCheckConfig(
+                        path="/",
+                    ),
+                ),
+                readiness=HealthCheck(
+                    enabled=True,
+                    port=self._jupyter_port,
+                    initial_delay_seconds=30,
+                    period_seconds=5,
+                    timeout=5,
+                    failure_threshold=20,
+                    health_check_config=HTTPHealthCheckConfig(
+                        path="/",
+                    ),
+                ),
+            ),
         )
 
         custom_app_vals = await self.custom_dep_val_processor.gen_extra_values(

--- a/src/apolo_app_types/helm/apps/mlflow.py
+++ b/src/apolo_app_types/helm/apps/mlflow.py
@@ -14,6 +14,11 @@ from apolo_app_types.protocols.common import (
     MountPath,
     StorageMounts,
 )
+from apolo_app_types.protocols.common.health_check import (
+    HealthCheck,
+    HealthCheckProbesConfig,
+    HTTPHealthCheckConfig,
+)
 from apolo_app_types.protocols.common.k8s import Port
 from apolo_app_types.protocols.custom_deployment import (
     CustomDeploymentInputs,
@@ -129,6 +134,30 @@ class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
                 ],
             ),
             storage_mounts=artifact_mounts,
+            health_checks=HealthCheckProbesConfig(
+                liveness=HealthCheck(
+                    enabled=True,
+                    port=5000,
+                    initial_delay_seconds=30,
+                    period_seconds=5,
+                    timeout=5,
+                    failure_threshold=20,
+                    health_check_config=HTTPHealthCheckConfig(
+                        path="/",
+                    ),
+                ),
+                readiness=HealthCheck(
+                    enabled=True,
+                    port=5000,
+                    initial_delay_seconds=30,
+                    period_seconds=5,
+                    timeout=5,
+                    failure_threshold=20,
+                    health_check_config=HTTPHealthCheckConfig(
+                        path="/",
+                    ),
+                ),
+            ),
         )
 
         custom_vals = await self.custom_dep_val_processor.gen_extra_values(

--- a/src/apolo_app_types/helm/apps/mlflow.py
+++ b/src/apolo_app_types/helm/apps/mlflow.py
@@ -39,6 +39,8 @@ class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
     - Artifact storage on Apolo Files
     """
 
+    _port = 5000
+
     def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
         super().__init__(*args, **kwargs)
         self.custom_dep_val_processor = CustomDeploymentChartValueProcessor(
@@ -109,7 +111,7 @@ class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
             "server",
             "--serve-artifacts",
             "--host=0.0.0.0",
-            "--port=5000",
+            f"--port={self._port}",
             f"--backend-store-uri={backend_uri}",
         ]
         if artifact_env_val:
@@ -130,31 +132,31 @@ class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
                 service_enabled=True,
                 ingress_http=input_.ingress_http,
                 ports=[
-                    Port(name="http", port=5000),
+                    Port(name="http", port=self._port),
                 ],
             ),
             storage_mounts=artifact_mounts,
             health_checks=HealthCheckProbesConfig(
                 liveness=HealthCheck(
                     enabled=True,
-                    port=5000,
-                    initial_delay_seconds=30,
+                    initial_delay=30,
                     period_seconds=5,
                     timeout=5,
                     failure_threshold=20,
                     health_check_config=HTTPHealthCheckConfig(
                         path="/",
+                        port=self._port,
                     ),
                 ),
                 readiness=HealthCheck(
                     enabled=True,
-                    port=5000,
-                    initial_delay_seconds=30,
+                    initial_delay=30,
                     period_seconds=5,
                     timeout=5,
                     failure_threshold=20,
                     health_check_config=HTTPHealthCheckConfig(
                         path="/",
+                        port=self._port,
                     ),
                 ),
             ),

--- a/src/apolo_app_types/helm/apps/privategpt.py
+++ b/src/apolo_app_types/helm/apps/privategpt.py
@@ -18,6 +18,11 @@ from apolo_app_types.protocols.common import (
     MountPath,
     StorageMounts,
 )
+from apolo_app_types.protocols.common.health_check import (
+    HealthCheck,
+    HealthCheckProbesConfig,
+    HTTPHealthCheckConfig,
+)
 from apolo_app_types.protocols.common.k8s import Container, Env, Port
 from apolo_app_types.protocols.common.openai_compat import get_api_base_url
 from apolo_app_types.protocols.custom_deployment import NetworkingConfig
@@ -117,6 +122,30 @@ class PrivateGptChartValueProcessor(BaseChartValueProcessor[PrivateGPTAppInputs]
                         mode=ApoloMountMode(mode="rw"),
                     ),
                 ]
+            ),
+            health_checks=HealthCheckProbesConfig(
+                liveness=HealthCheck(
+                    enabled=True,
+                    port=7865,
+                    initial_delay_seconds=30,
+                    period_seconds=5,
+                    timeout=5,
+                    failure_threshold=20,
+                    health_check_config=HTTPHealthCheckConfig(
+                        path="/",
+                    ),
+                ),
+                readiness=HealthCheck(
+                    enabled=True,
+                    port=7865,
+                    initial_delay_seconds=30,
+                    period_seconds=5,
+                    timeout=5,
+                    failure_threshold=20,
+                    health_check_config=HTTPHealthCheckConfig(
+                        path="/",
+                    ),
+                ),
             ),
         )
 

--- a/src/apolo_app_types/helm/apps/privategpt.py
+++ b/src/apolo_app_types/helm/apps/privategpt.py
@@ -30,6 +30,8 @@ from apolo_app_types.protocols.private_gpt import PrivateGPTAppInputs
 
 
 class PrivateGptChartValueProcessor(BaseChartValueProcessor[PrivateGPTAppInputs]):
+    _port = 8080
+
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
         self.custom_dep_val_processor = CustomDeploymentChartValueProcessor(
@@ -102,7 +104,7 @@ class PrivateGptChartValueProcessor(BaseChartValueProcessor[PrivateGPTAppInputs]
                 service_enabled=True,
                 ingress_http=input_.ingress_http,
                 ports=[
-                    Port(name="http", port=8080),
+                    Port(name="http", port=self._port),
                 ],
             ),
             storage_mounts=StorageMounts(
@@ -126,24 +128,24 @@ class PrivateGptChartValueProcessor(BaseChartValueProcessor[PrivateGPTAppInputs]
             health_checks=HealthCheckProbesConfig(
                 liveness=HealthCheck(
                     enabled=True,
-                    port=7865,
-                    initial_delay_seconds=30,
+                    initial_delay=30,
                     period_seconds=5,
                     timeout=5,
                     failure_threshold=20,
                     health_check_config=HTTPHealthCheckConfig(
                         path="/",
+                        port=self._port,
                     ),
                 ),
                 readiness=HealthCheck(
                     enabled=True,
-                    port=7865,
-                    initial_delay_seconds=30,
+                    initial_delay=30,
                     period_seconds=5,
                     timeout=5,
                     failure_threshold=20,
                     health_check_config=HTTPHealthCheckConfig(
                         path="/",
+                        port=self._port,
                     ),
                 ),
             ),

--- a/src/apolo_app_types/helm/apps/shell.py
+++ b/src/apolo_app_types/helm/apps/shell.py
@@ -100,24 +100,24 @@ class ShellChartValueProcessor(BaseChartValueProcessor[ShellAppInputs]):
             health_checks=HealthCheckProbesConfig(
                 liveness=HealthCheck(
                     enabled=True,
-                    port=self._port,
-                    initial_delay_seconds=30,
+                    initial_delay=30,
                     period_seconds=5,
                     timeout=5,
                     failure_threshold=20,
                     health_check_config=HTTPHealthCheckConfig(
                         path="/",
+                        port=self._port,
                     ),
                 ),
                 readiness=HealthCheck(
                     enabled=True,
-                    port=self._port,
-                    initial_delay_seconds=30,
+                    initial_delay=30,
                     period_seconds=5,
                     timeout=5,
                     failure_threshold=20,
                     health_check_config=HTTPHealthCheckConfig(
                         path="/",
+                        port=self._port,
                     ),
                 ),
             ),

--- a/src/apolo_app_types/helm/apps/vscode.py
+++ b/src/apolo_app_types/helm/apps/vscode.py
@@ -9,6 +9,11 @@ from apolo_app_types.helm.apps.custom_deployment import (
     CustomDeploymentChartValueProcessor,
 )
 from apolo_app_types.protocols.common import Container, Env, StorageMounts
+from apolo_app_types.protocols.common.health_check import (
+    HealthCheck,
+    HealthCheckProbesConfig,
+    HTTPHealthCheckConfig,
+)
 from apolo_app_types.protocols.common.ingress import IngressHttp
 from apolo_app_types.protocols.common.k8s import Port
 from apolo_app_types.protocols.custom_deployment import NetworkingConfig
@@ -69,6 +74,30 @@ class VSCodeChartValueProcessor(BaseChartValueProcessor[VSCodeAppInputs]):
                 ],
             ),
             storage_mounts=storage_mounts,
+            health_checks=HealthCheckProbesConfig(
+                liveness=HealthCheck(
+                    enabled=True,
+                    port=self._port,
+                    initial_delay_seconds=30,
+                    period_seconds=5,
+                    timeout=5,
+                    failure_threshold=20,
+                    health_check_config=HTTPHealthCheckConfig(
+                        path="/",
+                    ),
+                ),
+                readiness=HealthCheck(
+                    enabled=True,
+                    port=self._port,
+                    initial_delay_seconds=30,
+                    period_seconds=5,
+                    timeout=5,
+                    failure_threshold=20,
+                    health_check_config=HTTPHealthCheckConfig(
+                        path="/",
+                    ),
+                ),
+            ),
         )
 
         custom_app_vals = await self.custom_dep_val_processor.gen_extra_values(

--- a/src/apolo_app_types/helm/apps/vscode.py
+++ b/src/apolo_app_types/helm/apps/vscode.py
@@ -77,24 +77,24 @@ class VSCodeChartValueProcessor(BaseChartValueProcessor[VSCodeAppInputs]):
             health_checks=HealthCheckProbesConfig(
                 liveness=HealthCheck(
                     enabled=True,
-                    port=self._port,
-                    initial_delay_seconds=30,
+                    initial_delay=30,
                     period_seconds=5,
                     timeout=5,
                     failure_threshold=20,
                     health_check_config=HTTPHealthCheckConfig(
                         path="/",
+                        port=self._port,
                     ),
                 ),
                 readiness=HealthCheck(
                     enabled=True,
-                    port=self._port,
-                    initial_delay_seconds=30,
+                    initial_delay=30,
                     period_seconds=5,
                     timeout=5,
                     failure_threshold=20,
                     health_check_config=HTTPHealthCheckConfig(
                         path="/",
+                        port=self._port,
                     ),
                 ),
             ),

--- a/src/apolo_app_types/helm/utils/pods.py
+++ b/src/apolo_app_types/helm/utils/pods.py
@@ -1,0 +1,55 @@
+import typing as t
+
+from apolo_app_types.protocols.common.health_check import (
+    HealthCheck,
+    HealthCheckProbesConfig,
+    ProbeType,
+)
+
+
+def get_probe_values(config: HealthCheck) -> dict[str, t.Any]:
+    values: dict[str, t.Any] = {
+        "initialDelaySeconds": config.initial_delay,
+        "timeoutSeconds": config.timeout,
+        "periodSeconds": config.period,
+        "failureThreshold": config.failure_threshold,
+    }
+    if config.health_check_config.probe_type == ProbeType.TCP:
+        values["tcpSocket"] = {"port": config.port}
+    elif config.health_check_config.probe_type == ProbeType.HTTP:
+        values["httpGet"] = {
+            "path": config.health_check_config.path,
+            "port": config.port,
+        }
+        if config.health_check_config.http_headers:
+            values["httpGet"]["httpHeaders"] = [
+                {"name": k, "value": v}
+                for k, v in config.health_check_config.http_headers.items()
+            ]
+    elif config.health_check_config.probe_type == ProbeType.GRPC:
+        values["grpc"] = {
+            "port": config.port,
+            "service": config.health_check_config.service,
+        }
+    else:
+        err = f"Unsupported probe type: {config.health_check_config.probe_type}"
+        raise ValueError(err)
+    return values
+
+
+def get_health_check_values(
+    health_checks: HealthCheckProbesConfig | None,
+) -> dict[str, t.Any]:
+    if not health_checks:
+        return {}
+    values: dict[str, t.Any] = {"health_checks": {}}
+    if health_checks.startup:
+        values["health_checks"]["startupProbe"] = get_probe_values(
+            health_checks.startup
+        )
+
+    if health_checks.liveness:
+        values["health_checks"]["livenessProbe"] = get_probe_values(
+            health_checks.liveness
+        )
+    return values

--- a/src/apolo_app_types/helm/utils/pods.py
+++ b/src/apolo_app_types/helm/utils/pods.py
@@ -15,11 +15,11 @@ def get_probe_values(config: HealthCheck) -> dict[str, t.Any]:
         "failureThreshold": config.failure_threshold,
     }
     if config.health_check_config.probe_type == ProbeType.TCP:
-        values["tcpSocket"] = {"port": config.port}
+        values["tcpSocket"] = {"port": config.health_check_config.port}
     elif config.health_check_config.probe_type == ProbeType.HTTP:
         values["httpGet"] = {
             "path": config.health_check_config.path,
-            "port": config.port,
+            "port": config.health_check_config.port,
         }
         if config.health_check_config.http_headers:
             values["httpGet"]["httpHeaders"] = [
@@ -28,7 +28,7 @@ def get_probe_values(config: HealthCheck) -> dict[str, t.Any]:
             ]
     elif config.health_check_config.probe_type == ProbeType.GRPC:
         values["grpc"] = {
-            "port": config.port,
+            "port": config.health_check_config.port,
             "service": config.health_check_config.service,
         }
     elif config.health_check_config.probe_type == ProbeType.EXEC:
@@ -41,7 +41,7 @@ def get_probe_values(config: HealthCheck) -> dict[str, t.Any]:
     return values
 
 
-def get_health_check_values(
+def get_custom_deployment_health_check_values(
     health_checks: HealthCheckProbesConfig | None,
 ) -> dict[str, t.Any]:
     if not health_checks:

--- a/src/apolo_app_types/helm/utils/pods.py
+++ b/src/apolo_app_types/helm/utils/pods.py
@@ -52,4 +52,9 @@ def get_health_check_values(
         values["health_checks"]["livenessProbe"] = get_probe_values(
             health_checks.liveness
         )
+
+    if health_checks.readiness:
+        values["health_checks"]["readinessProbe"] = get_probe_values(
+            health_checks.readiness
+        )
     return values

--- a/src/apolo_app_types/helm/utils/pods.py
+++ b/src/apolo_app_types/helm/utils/pods.py
@@ -31,6 +31,10 @@ def get_probe_values(config: HealthCheck) -> dict[str, t.Any]:
             "port": config.port,
             "service": config.health_check_config.service,
         }
+    elif config.health_check_config.probe_type == ProbeType.EXEC:
+        values["exec"] = {
+            "command": config.health_check_config.command,
+        }
     else:
         err = f"Unsupported probe type: {config.health_check_config.probe_type}"
         raise ValueError(err)

--- a/src/apolo_app_types/protocols/common/health_check.py
+++ b/src/apolo_app_types/protocols/common/health_check.py
@@ -202,3 +202,10 @@ class HealthCheckProbesConfig(AbstractAppFieldType):
             description="Configuration for liveness probe",
         ).as_json_schema_extra(),
     )
+    readiness: HealthCheck | None = Field(
+        default=None,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Readiness Probe",
+            description="Configuration for liveness probe",
+        ).as_json_schema_extra(),
+    )

--- a/src/apolo_app_types/protocols/common/health_check.py
+++ b/src/apolo_app_types/protocols/common/health_check.py
@@ -1,0 +1,204 @@
+from enum import Enum
+from typing import Literal
+
+from pydantic import ConfigDict, Field, field_validator
+
+from apolo_app_types.protocols.common.abc_ import AbstractAppFieldType
+from apolo_app_types.protocols.common.schema_extra import (
+    SchemaExtraMetadata,
+    SchemaMetaType,
+)
+
+
+class HealthCheckType(str, Enum):
+    STARTUP = "Startup check"
+    LIVENESS = "Liveness check"
+
+
+class ProbeType(str, Enum):
+    HTTP = "HTTP"
+    GRPC = "gRPC"
+    TCP = "TCP"
+
+
+class HTTPHealthCheckConfig(AbstractAppFieldType):
+    """
+    HTTP-specific health check configuration.
+    """
+
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="HTTP Health Check",
+            description="Configuration for HTTP health checks.",
+            meta_type=SchemaMetaType.INLINE,
+        ).as_json_schema_extra(),
+    )
+    probe_type: Literal[ProbeType.HTTP] = Field(default=ProbeType.HTTP)
+    path: str = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Path",
+            description="Path to access on the HTTP server",
+        ).as_json_schema_extra(),
+    )
+    http_headers: dict[str, str] | None = Field(
+        None,
+        json_schema_extra=SchemaExtraMetadata(
+            title="HTTP Headers",
+            description="Custom headers to set in the request",
+        ).as_json_schema_extra(),
+    )
+
+
+class GRPCHealthCheckConfig(AbstractAppFieldType):
+    """
+    gRPC-specific health check configuration.
+    """
+
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="gRPC Health Check",
+            description="Configuration for gRPC health checks.",
+            meta_type=SchemaMetaType.INLINE,
+        ).as_json_schema_extra(),
+    )
+    probe_type: Literal[ProbeType.GRPC] = Field(default=ProbeType.GRPC)
+    service: str = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Service",
+            description="The name of the gRPC service to probe",
+        ).as_json_schema_extra(),
+    )
+
+
+class TCPHealthCheckConfig(AbstractAppFieldType):
+    """
+    TCP-specific health check configuration.
+    """
+
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="TCP Health Check",
+            description="Configuration for TCP health checks.",
+            meta_type=SchemaMetaType.INLINE,
+        ).as_json_schema_extra(),
+    )
+    probe_type: Literal[ProbeType.TCP] = Field(default=ProbeType.TCP)
+    # No additional fields needed for TCP, just the connection attempt itself
+
+
+HealthCheckConfig = HTTPHealthCheckConfig | GRPCHealthCheckConfig | TCPHealthCheckConfig
+
+
+class HealthCheck(AbstractAppFieldType):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Health Check",
+            description="Configuration for health checks on the application.",
+            meta_type=SchemaMetaType.INLINE,
+        ).as_json_schema_extra(),
+    )
+    # probe_type: ProbeType = Field(
+    #     ...,
+    #     json_schema_extra=SchemaExtraMetadata(
+    #         title="Probe Type",
+    #         description="Type of probe to use for health check",
+    #     ).as_json_schema_extra()
+    # )
+    # health_check_type: HealthCheckType = Field(
+    #     HealthCheckType.STARTUP,
+    #     json_schema_extra=SchemaExtraMetadata(
+    #         title="Health Check Type",
+    #         description="Type of health check",
+    #     ).as_json_schema_extra()
+    # )
+    port: int = Field(
+        default=8080,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Port",
+            description="Port to make a connection for the Custom Deployment instance",
+        ).as_json_schema_extra(),
+    )
+    initial_delay: int = Field(
+        0,
+        ge=0,
+        le=240,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Initial Delay",
+            description="Number of seconds after the container has started "
+            "before performing the first probe",
+        ).as_json_schema_extra(),
+    )
+    period: int = Field(
+        10,
+        ge=1,
+        le=240,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Period",
+            description="Number of seconds to wait between starting a probe attempt",
+        ).as_json_schema_extra(),
+    )
+    failure_threshold: int = Field(
+        3,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Failure Threshold",
+            description="Number of times to retry the probe before marking "
+            "the container as Unready",
+        ).as_json_schema_extra(),
+    )
+    timeout: int = Field(
+        1,
+        ge=1,
+        le=240,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Timeout",
+            description="Number of seconds after which the probe times out",
+        ).as_json_schema_extra(),
+    )
+
+    health_check_config: HealthCheckConfig
+
+    @field_validator("timeout")
+    @classmethod
+    def timeout_less_than_period(cls, v: int, info) -> int:  # type: ignore
+        if "period" in info.data and v > info.data["period"]:
+            err = "Timeout value shouldn't exceed Period seconds"
+            raise ValueError(err)
+        return v
+
+
+# Union type for accepting any of the health check types
+
+
+class HealthCheckProbesConfig(AbstractAppFieldType):
+    """
+    Configuration for health check probes.
+    """
+
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Health Check Probes",
+            description="Configuration for health check probes.",
+            meta_type=SchemaMetaType.INLINE,
+        ).as_json_schema_extra(),
+    )
+    startup: HealthCheck | None = Field(
+        default=None,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Startup Probe",
+            description="Configuration for startup probe",
+        ).as_json_schema_extra(),
+    )
+    liveness: HealthCheck | None = Field(
+        default=None,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Liveness Probe",
+            description="Configuration for liveness probe",
+        ).as_json_schema_extra(),
+    )

--- a/src/apolo_app_types/protocols/common/health_check.py
+++ b/src/apolo_app_types/protocols/common/health_check.py
@@ -10,11 +10,6 @@ from apolo_app_types.protocols.common.schema_extra import (
 )
 
 
-class HealthCheckType(str, Enum):
-    STARTUP = "Startup check"
-    LIVENESS = "Liveness check"
-
-
 class ProbeType(str, Enum):
     HTTP = "HTTP"
     GRPC = "gRPC"
@@ -132,20 +127,6 @@ class HealthCheck(AbstractAppFieldType):
             meta_type=SchemaMetaType.INLINE,
         ).as_json_schema_extra(),
     )
-    # probe_type: ProbeType = Field(
-    #     ...,
-    #     json_schema_extra=SchemaExtraMetadata(
-    #         title="Probe Type",
-    #         description="Type of probe to use for health check",
-    #     ).as_json_schema_extra()
-    # )
-    # health_check_type: HealthCheckType = Field(
-    #     HealthCheckType.STARTUP,
-    #     json_schema_extra=SchemaExtraMetadata(
-    #         title="Health Check Type",
-    #         description="Type of health check",
-    #     ).as_json_schema_extra()
-    # )
     port: int = Field(
         default=8080,
         json_schema_extra=SchemaExtraMetadata(

--- a/src/apolo_app_types/protocols/common/health_check.py
+++ b/src/apolo_app_types/protocols/common/health_check.py
@@ -17,7 +17,27 @@ class ProbeType(str, Enum):
     EXEC = "Exec"
 
 
-class HTTPHealthCheckConfig(AbstractAppFieldType):
+class HealthCheckConfigBase(AbstractAppFieldType):
+    """Base class for health check configurations."""
+
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Health Check Config Base",
+            description="Base configuration for health checks.",
+            meta_type=SchemaMetaType.INLINE,
+        ).as_json_schema_extra(),
+    )
+    port: int = Field(
+        default=8080,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Port",
+            description="Port to make a connection for the Custom Deployment instance",
+        ).as_json_schema_extra(),
+    )
+
+
+class HTTPHealthCheckConfig(HealthCheckConfigBase):
     """
     HTTP-specific health check configuration.
     """
@@ -47,7 +67,7 @@ class HTTPHealthCheckConfig(AbstractAppFieldType):
     )
 
 
-class GRPCHealthCheckConfig(AbstractAppFieldType):
+class GRPCHealthCheckConfig(HealthCheckConfigBase):
     """
     gRPC-specific health check configuration.
     """
@@ -70,7 +90,7 @@ class GRPCHealthCheckConfig(AbstractAppFieldType):
     )
 
 
-class TCPHealthCheckConfig(AbstractAppFieldType):
+class TCPHealthCheckConfig(HealthCheckConfigBase):
     """
     TCP-specific health check configuration.
     """
@@ -87,7 +107,7 @@ class TCPHealthCheckConfig(AbstractAppFieldType):
     # No additional fields needed for TCP, just the connection attempt itself
 
 
-class ExecHealthCheckConfig(AbstractAppFieldType):
+class ExecHealthCheckConfig(HealthCheckConfigBase):
     """
     Exec-specific health check configuration.
     """
@@ -125,13 +145,6 @@ class HealthCheck(AbstractAppFieldType):
             title="Health Check",
             description="Configuration for health checks on the application.",
             meta_type=SchemaMetaType.INLINE,
-        ).as_json_schema_extra(),
-    )
-    port: int = Field(
-        default=8080,
-        json_schema_extra=SchemaExtraMetadata(
-            title="Port",
-            description="Port to make a connection for the Custom Deployment instance",
         ).as_json_schema_extra(),
     )
     initial_delay: int = Field(

--- a/src/apolo_app_types/protocols/common/health_check.py
+++ b/src/apolo_app_types/protocols/common/health_check.py
@@ -19,6 +19,7 @@ class ProbeType(str, Enum):
     HTTP = "HTTP"
     GRPC = "gRPC"
     TCP = "TCP"
+    EXEC = "Exec"
 
 
 class HTTPHealthCheckConfig(AbstractAppFieldType):
@@ -91,7 +92,35 @@ class TCPHealthCheckConfig(AbstractAppFieldType):
     # No additional fields needed for TCP, just the connection attempt itself
 
 
-HealthCheckConfig = HTTPHealthCheckConfig | GRPCHealthCheckConfig | TCPHealthCheckConfig
+class ExecHealthCheckConfig(AbstractAppFieldType):
+    """
+    Exec-specific health check configuration.
+    """
+
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Exec Health Check",
+            description="Configuration for exec health checks.",
+            meta_type=SchemaMetaType.INLINE,
+        ).as_json_schema_extra(),
+    )
+    probe_type: Literal[ProbeType.EXEC] = Field(default=ProbeType.EXEC)
+    command: list[str] = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Command",
+            description="Command to execute for the health check",
+        ).as_json_schema_extra(),
+    )
+
+
+HealthCheckConfig = (
+    HTTPHealthCheckConfig
+    | GRPCHealthCheckConfig
+    | TCPHealthCheckConfig
+    | ExecHealthCheckConfig
+)
 
 
 class HealthCheck(AbstractAppFieldType):

--- a/src/apolo_app_types/protocols/custom_deployment.py
+++ b/src/apolo_app_types/protocols/custom_deployment.py
@@ -12,6 +12,9 @@ from apolo_app_types.protocols.common import (
     SchemaExtraMetadata,
     StorageMounts,
 )
+from apolo_app_types.protocols.common.health_check import (
+    HealthCheckProbesConfig,
+)
 from apolo_app_types.protocols.common.k8s import Port
 
 
@@ -88,6 +91,7 @@ class CustomDeploymentInputs(AppInputs):
         ).as_json_schema_extra(),
     )
     networking: NetworkingConfig = Field(default_factory=lambda: NetworkingConfig())
+    health_checks: HealthCheckProbesConfig | None = Field(default=None)
 
 
 class CustomDeploymentOutputs(AppOutputs):

--- a/src/apolo_app_types/protocols/jupyter.py
+++ b/src/apolo_app_types/protocols/jupyter.py
@@ -58,10 +58,8 @@ class Networking(AbstractAppFieldType):
     )
     http_auth: bool = Field(
         default=True,
-        json_schema_extra=SchemaExtraMetadata(
-            description="Enable platform provided HTTP authentication.",
-            title="HTTP Authentication",
-        ).as_json_schema_extra(),
+        description="Whether to use HTTP authentication.",
+        title="HTTP Authentication",
     )
 
 
@@ -75,10 +73,8 @@ class JupyterSpecificAppInputs(AbstractAppFieldType):
     )
     jupyter_type: JupyterTypes = Field(
         default=JupyterTypes.LAB,
-        json_schema_extra=SchemaExtraMetadata(
-            description="Set the type of Jupyter application (lab or notebook).",
-            title="Jupyter Type",
-        ).as_json_schema_extra(),
+        description="Set the type of Jupyter application (lab or notebook).",
+        title="Jupyter Type",
     )
     code_storage_mount: ApoloFilesMount = Field(
         default=ApoloFilesMount(

--- a/tests/unit/custom_deployment/test_custom_deployment_input_generation.py
+++ b/tests/unit/custom_deployment/test_custom_deployment_input_generation.py
@@ -419,3 +419,11 @@ async def test_custom_deployment_values_generation_with_health_checks(
         "initialDelaySeconds": 5,
         "periodSeconds": 10,
     }
+    assert "readinessProbe" in helm_params["health_checks"]
+    assert helm_params["health_checks"]["readinessProbe"] == {
+        "tcpSocket": {"port": 8080},
+        "failureThreshold": 3,
+        "timeoutSeconds": 1,
+        "initialDelaySeconds": 5,
+        "periodSeconds": 10,
+    }

--- a/tests/unit/custom_deployment/test_custom_deployment_input_generation.py
+++ b/tests/unit/custom_deployment/test_custom_deployment_input_generation.py
@@ -15,6 +15,7 @@ from apolo_app_types.protocols.common.health_check import (
     HealthCheck,
     HealthCheckProbesConfig,
     HTTPHealthCheckConfig,
+    TCPHealthCheckConfig,
 )
 from apolo_app_types.protocols.common.k8s import Port
 from apolo_app_types.protocols.common.storage import (
@@ -356,14 +357,25 @@ async def test_custom_deployment_values_generation_with_health_checks(
                 liveness=HealthCheck(
                     period=30,
                     initial_delay=10,
-                    port=8080,
-                    health_check_config=HTTPHealthCheckConfig(path="/health"),
+                    health_check_config=HTTPHealthCheckConfig(
+                        path="/health",
+                        port=8080,
+                    ),
                 ),
                 startup=HealthCheck(
                     period=10,
                     initial_delay=5,
-                    port=8080,
-                    health_check_config=GRPCHealthCheckConfig(service="service-name"),
+                    health_check_config=GRPCHealthCheckConfig(
+                        service="service-name",
+                        port=8080,
+                    ),
+                ),
+                readiness=HealthCheck(
+                    period=10,
+                    initial_delay=5,
+                    health_check_config=TCPHealthCheckConfig(
+                        port=8080,
+                    ),
                 ),
             ),
         ),

--- a/tests/unit/custom_deployment/test_custom_deployment_input_generation.py
+++ b/tests/unit/custom_deployment/test_custom_deployment_input_generation.py
@@ -10,6 +10,12 @@ from apolo_app_types import (
 from apolo_app_types.app_types import AppType
 from apolo_app_types.inputs.args import app_type_to_vals
 from apolo_app_types.protocols.common import IngressHttp, Preset
+from apolo_app_types.protocols.common.health_check import (
+    GRPCHealthCheckConfig,
+    HealthCheck,
+    HealthCheckProbesConfig,
+    HTTPHealthCheckConfig,
+)
 from apolo_app_types.protocols.common.k8s import Port
 from apolo_app_types.protocols.common.storage import (
     ApoloFilesMount,
@@ -317,3 +323,87 @@ async def test_custom_deployment_values_generation_network_not_supplied(
     assert helm_params["ingress"]["hosts"][0]["paths"] == [
         {"path": "/", "pathType": "Prefix", "portName": "http"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_custom_deployment_values_generation_with_health_checks(
+    setup_clients,
+):
+    """
+    Ensure that when health checks are provided, they are properly
+    configured in the helm values
+    """
+    helm_args, helm_params = await app_type_to_vals(
+        input_=CustomDeploymentInputs(
+            preset=Preset(name="cpu-small"),
+            image=ContainerImage(
+                repository="myrepo/custom-deployment",
+                tag="v1.2.3",
+            ),
+            container=Container(
+                command=["python", "app.py"],
+                args=["--port", "8080"],
+                env=[Env(name="ENV_VAR", value="value")],
+            ),
+            networking=NetworkingConfig(
+                service_enabled=True,
+                ports=[
+                    Port(name="http", port=8080),
+                ],
+                ingress_http=IngressHttp(),
+            ),
+            health_checks=HealthCheckProbesConfig(
+                liveness=HealthCheck(
+                    period=30,
+                    initial_delay=10,
+                    port=8080,
+                    health_check_config=HTTPHealthCheckConfig(path="/health"),
+                ),
+                startup=HealthCheck(
+                    period=10,
+                    initial_delay=5,
+                    port=8080,
+                    health_check_config=GRPCHealthCheckConfig(service="service-name"),
+                ),
+            ),
+        ),
+        apolo_client=setup_clients,
+        app_type=AppType.CustomDeployment,
+        app_name="custom-app",
+        namespace="default-namespace",
+        app_secrets_name=APP_SECRETS_NAME,
+    )
+
+    # Base assertions
+    assert helm_params["image"] == {
+        "repository": "myrepo/custom-deployment",
+        "tag": "v1.2.3",
+    }
+    assert helm_params["container"] == {
+        "command": ["python", "app.py"],
+        "args": ["--port", "8080"],
+        "env": [{"name": "ENV_VAR", "value": "value"}],
+    }
+    assert helm_params["service"] == {
+        "enabled": True,
+        "ports": [{"name": "http", "containerPort": 8080}],
+    }
+
+    # Health check assertions
+    assert "health_checks" in helm_params
+    assert "livenessProbe" in helm_params["health_checks"]
+    assert helm_params["health_checks"]["livenessProbe"] == {
+        "httpGet": {"path": "/health", "port": 8080},
+        "failureThreshold": 3,
+        "timeoutSeconds": 1,
+        "initialDelaySeconds": 10,
+        "periodSeconds": 30,
+    }
+    assert "startupProbe" in helm_params["health_checks"]
+    assert helm_params["health_checks"]["startupProbe"] == {
+        "grpc": {"port": 8080, "service": "service-name"},
+        "failureThreshold": 3,
+        "timeoutSeconds": 1,
+        "initialDelaySeconds": 5,
+        "periodSeconds": 10,
+    }


### PR DESCRIPTION
This pull request introduces a the option to customize health checks for Custom Deployment applications, including support for HTTP, gRPC, TCP and exec probes. 

It also adds health check configurations to all the apps that previously relied on the default health check in the Custom Deployment chart. 

Resulting UI: 

[Screencast From 2025-05-20 15-02-02.webm](https://github.com/user-attachments/assets/e5b7c3fd-355e-4a93-9087-27429ef2c703)


This makes use of `const` field, which isn't currently supported on the UI.

The most significant changes are grouped below by theme.

### Health Check Framework Implementation:
* Added new health check-related classes (`HealthCheck`, `HealthCheckProbesConfig`, `HTTPHealthCheckConfig`, `GRPCHealthCheckConfig`, `TCPHealthCheckConfig`) in `src/apolo_app_types/protocols/common/health_check.py` to define reusable configurations for liveness, readiness, and startup probes.
* Introduced utility functions `get_probe_values` and `get_health_check_values` in `src/apolo_app_types/helm/utils/pods.py` to generate Kubernetes health check values based on the new configurations.

### Integration with Helm Applications:
* Updated `gen_extra_values` methods in Helm app charts (`fooocus.py`, `jupyter.py`, `mlflow.py`, `privategpt.py`, `shell.py`, `vscode.py`) to include health check configurations using the new `HealthCheckProbesConfig`. [[1]](diffhunk://#diff-7fb9f637ad26dedfcc3cbe8bb1a1fe5c60dbb33fff9a140eada26e7f93a76bc8R126-R149) [[2]](diffhunk://#diff-37bba5bd2351de46949719c0f8fc4e3600eff6f2ac9741ec4d454310539c1145R106-R129) [[3]](diffhunk://#diff-7a28904f8efdd3318d3f808c9c450f78edc8bc43f68f6cdc1585fa3d9965ddc8R137-R160) [[4]](diffhunk://#diff-7cde115f4d1c7d2e862ffa060103af5484f0daeeb6155bd247de6016d290b4cbR126-R149) [[5]](diffhunk://#diff-84735ea25bc495dfa3154dfa9d6facc46ac34e9aaedad5645edb65b2f983348bR100-R123) [[6]](diffhunk://#diff-6f4445b9a242f85cf0ccfb5b2d5b4d1325c484020401c90b5c307702dff10cd5R77-R100)
* Added imports for health check-related classes in the respective Helm app chart files. [[1]](diffhunk://#diff-7fb9f637ad26dedfcc3cbe8bb1a1fe5c60dbb33fff9a140eada26e7f93a76bc8R25-R29) [[2]](diffhunk://#diff-37bba5bd2351de46949719c0f8fc4e3600eff6f2ac9741ec4d454310539c1145R14-R18) [[3]](diffhunk://#diff-7a28904f8efdd3318d3f808c9c450f78edc8bc43f68f6cdc1585fa3d9965ddc8R17-R21) [[4]](diffhunk://#diff-7cde115f4d1c7d2e862ffa060103af5484f0daeeb6155bd247de6016d290b4cbR21-R25) [[5]](diffhunk://#diff-84735ea25bc495dfa3154dfa9d6facc46ac34e9aaedad5645edb65b2f983348bR24-R37) [[6]](diffhunk://#diff-6f4445b9a242f85cf0ccfb5b2d5b4d1325c484020401c90b5c307702dff10cd5R12-R16)

### Enhancements to Custom Deployment:
* Updated `CustomDeploymentInputs` in `src/apolo_app_types/protocols/custom_deployment.py` to include an optional `health_checks` field for defining health check configurations at the deployment level.
* Integrated the `get_health_check_values` utility in `src/apolo_app_types/helm/apps/custom_deployment.py` to process health check configurations in `gen_extra_values`. [[1]](diffhunk://#diff-ce4a4d8545961c4d5c5f952a4c5bbef6c8babc95421477ad2829a1fe9aee4a99R14) [[2]](diffhunk://#diff-ce4a4d8545961c4d5c5f952a4c5bbef6c8babc95421477ad2829a1fe9aee4a99R135-R138)

These changes collectively enhance the robustness and maintainability of health check configurations across Kubernetes deployments.