### PR TITLE
Refactor MLFlow output to use new ServiceAPI class

### DIFF
--- a/src/apolo_app_types/helm/apps/jupyter.py
+++ b/src/apolo_app_types/helm/apps/jupyter.py
@@ -61,11 +61,11 @@ class JupyterChartValueProcessor(BaseChartValueProcessor[JupyterAppInputs]):
             cmd = "notebook"
 
         env_vars = []
-        if input_.mlflow_integration and input_.mlflow_integration.internal_web_app_url:
+        if input_.mlflow_integration and input_.mlflow_integration.internal_url:
             env_vars.append(
                 Env(
                     name="MLFLOW_TRACKING_URI",
-                    value=input_.mlflow_integration.internal_web_app_url.complete_url,
+                    value=input_.mlflow_integration.internal_url.complete_url,
                 )
             )
 

--- a/src/apolo_app_types/helm/apps/vscode.py
+++ b/src/apolo_app_types/helm/apps/vscode.py
@@ -44,11 +44,11 @@ class VSCodeChartValueProcessor(BaseChartValueProcessor[VSCodeAppInputs]):
         env_vars = [
             Env(name="CODER_HTTP_ADDRESS", value=f"0.0.0.0:{self._port}"),
         ]
-        if input_.mlflow_integration and input_.mlflow_integration.internal_web_app_url:
+        if input_.mlflow_integration and input_.mlflow_integration.internal_url:
             env_vars.append(
                 Env(
                     name="MLFLOW_TRACKING_URI",
-                    value=input_.mlflow_integration.internal_web_app_url.complete_url,
+                    value=input_.mlflow_integration.internal_url.complete_url,
                 )
             )
 

--- a/src/apolo_app_types/outputs/mlflow.py
+++ b/src/apolo_app_types/outputs/mlflow.py
@@ -4,6 +4,7 @@ from apolo_app_types import MLFlowAppOutputs, MLFlowTrackingServerURL
 from apolo_app_types.clients.kube import get_service_host_port
 from apolo_app_types.outputs.common import get_internal_external_web_urls
 from apolo_app_types.outputs.utils.ingress import get_ingress_host_port
+from apolo_app_types.protocols.common.networking import HttpApi, ServiceAPI
 
 
 async def get_mlflow_outputs(
@@ -35,8 +36,12 @@ async def get_mlflow_outputs(
         )
 
     return MLFlowAppOutputs(
-        internal_web_app_url=internal_web_app_url,
-        external_web_app_url=external_web_app_url,
-        internal_server_url=internal_server_url,
-        external_server_url=external_server_url,
+        web_app_url=ServiceAPI[HttpApi](
+            internal_url=internal_web_app_url,
+            external_url=external_web_app_url,
+        ),
+        server_url=MLFlowTrackingServerURL(
+            internal_url=internal_server_url,
+            external_url=external_server_url,
+        ),
     ).model_dump()

--- a/src/apolo_app_types/protocols/common/__init__.py
+++ b/src/apolo_app_types/protocols/common/__init__.py
@@ -13,7 +13,7 @@ from .containers import ContainerImage
 from .hugging_face import HuggingFaceCache, HuggingFaceModel
 from .ingress import IngressGrpc, IngressHttp
 from .k8s import Container, DeploymentName, Env
-from .networking import GraphQLAPI, GrpcAPI, RestAPI
+from .networking import GraphQLAPI, GrpcAPI, RestAPI, ServiceAPI
 from .openai_compat import OpenAICompatChatAPI, OpenAICompatEmbeddingsAPI
 from .postgres import Postgres
 from .preset import Preset
@@ -50,6 +50,7 @@ __all__ = [
     "GrpcAPI",
     "RestAPI",
     "GraphQLAPI",
+    "ServiceAPI",
     "ApoloSecret",
     "StrOrSecret",
     "OptionalStrOrSecret",

--- a/src/apolo_app_types/protocols/common/networking.py
+++ b/src/apolo_app_types/protocols/common/networking.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Generic, Literal, TypeVar
 
 from pydantic import ConfigDict, Field
 
@@ -60,3 +60,38 @@ class RestAPI(HttpApi):
 
 class GrpcAPI(HttpApi):
     api_type: Literal["grpc"] = "grpc"
+
+
+API_TYPE = TypeVar("API_TYPE", bound=HttpApi)
+
+
+class ServiceAPI(AbstractAppFieldType, Generic[API_TYPE]):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Service APIs",
+            description="Service APIs URLs.",
+            meta_type=SchemaMetaType.INTEGRATION,
+        ).as_json_schema_extra(),
+    )
+    internal_url: API_TYPE | None = Field(
+        default=None,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Internal URL",
+            description="Internal URL to access the service. "
+            "This route is not protected by platform authorization "
+            "and only workloads from the same project can access it.",
+        ).as_json_schema_extra(),
+    )
+    external_url: API_TYPE | None = Field(
+        default=None,
+        json_schema_extra=SchemaExtraMetadata(
+            title="External URL",
+            description="External URL for accessing the service "
+            "from outside the cluster. "
+            "This route is secured by platform "
+            "authorization and is accessible from any "
+            "network with a valid platform authorization"
+            " token that has appropriate permissions.",
+        ).as_json_schema_extra(),
+    )

--- a/src/apolo_app_types/protocols/common/networking.py
+++ b/src/apolo_app_types/protocols/common/networking.py
@@ -89,7 +89,7 @@ class ServiceAPI(AbstractAppFieldType, Generic[API_TYPE]):
             title="External URL",
             description="External URL for accessing the service "
             "from outside the cluster. "
-            "This route is secured by platform "
+            "This route might be secured by platform "
             "authorization and is accessible from any "
             "network with a valid platform authorization"
             " token that has appropriate permissions.",

--- a/src/apolo_app_types/protocols/jupyter.py
+++ b/src/apolo_app_types/protocols/jupyter.py
@@ -20,7 +20,7 @@ from apolo_app_types.protocols.common.storage import (
     MountPath,
     StorageMounts,
 )
-from apolo_app_types.protocols.mlflow import MLFlowAppOutputs
+from apolo_app_types.protocols.mlflow import MLFlowTrackingServerURL
 
 
 class JupyterTypes(str, Enum):
@@ -118,7 +118,7 @@ class JupyterAppInputs(AppInputs):
         ).as_json_schema_extra(),
     )
 
-    mlflow_integration: MLFlowAppOutputs | None = Field(
+    mlflow_integration: MLFlowTrackingServerURL | None = Field(
         default=None,
         json_schema_extra=SchemaExtraMetadata(
             title="MLFlow Integration",

--- a/src/apolo_app_types/protocols/mlflow.py
+++ b/src/apolo_app_types/protocols/mlflow.py
@@ -10,6 +10,7 @@ from apolo_app_types.protocols.common import (
     RestAPI,
     SchemaExtraMetadata,
 )
+from apolo_app_types.protocols.common.networking import HttpApi, ServiceAPI
 from apolo_app_types.protocols.postgres import PostgresURI
 
 
@@ -71,7 +72,7 @@ class MLFlowAppInputs(AppInputs):
     )
 
 
-class MLFlowTrackingServerURL(RestAPI):
+class MLFlowTrackingServerURL(ServiceAPI[RestAPI]):
     model_config = ConfigDict(
         protected_namespaces=(),
         json_schema_extra=SchemaExtraMetadata(
@@ -82,54 +83,18 @@ class MLFlowTrackingServerURL(RestAPI):
 
 
 class MLFlowAppOutputs(AppOutputs):
-    internal_web_app_url: RestAPI | None = Field(
-        default=None,
+    web_app_url: ServiceAPI[HttpApi] = Field(
+        default=ServiceAPI[HttpApi](),
         json_schema_extra=SchemaExtraMetadata(
-            title="Internal MLFlow URL",
-            description=(
-                "Internal URL to access the MLFlow web "
-                "app and API from inside the cluster. "
-                "This route is not protected by platform authorization "
-                "and only workloads from the same project can access it."
-            ),
+            title="MLFlow Web App URL",
+            description=("URL to access the MLFlow web application. "),
         ).as_json_schema_extra(),
     )
-    external_web_app_url: RestAPI | None = Field(
+
+    server_url: MLFlowTrackingServerURL | None = Field(
         default=None,
         json_schema_extra=SchemaExtraMetadata(
-            title="External MLFlow URL",
-            description=(
-                "External URL for accessing the MLFlow web "
-                "application and API from outside the cluster. "
-                "This route is secured by platform "
-                "authorization and is accessible from any "
-                "network with a valid platform authorization"
-                " token that has appropriate permissions."
-            ),
-        ).as_json_schema_extra(),
-    )
-    internal_server_url: MLFlowTrackingServerURL | None = Field(
-        default=None,
-        json_schema_extra=SchemaExtraMetadata(
-            title="Internal MLFlow Server URL",
-            description=(
-                "Internal URL to access the MLFlow tracking server "
-                "from inside the cluster. This route is not protected "
-                "by platform authorization and only workloads from "
-                "the same project can access it."
-            ),
-        ).as_json_schema_extra(),
-    )
-    external_server_url: MLFlowTrackingServerURL | None = Field(
-        default=None,
-        json_schema_extra=SchemaExtraMetadata(
-            title="External MLFlow Server URL",
-            description=(
-                "External URL for accessing the MLFlow tracking server "
-                "from outside the cluster. This route is secured by "
-                "platform authorization and is accessible from any "
-                "network with a valid platform authorization token "
-                "that has appropriate permissions."
-            ),
+            title="MLFlow Tracking Server URL",
+            description=("URL to access the MLFlow tracking server. "),
         ).as_json_schema_extra(),
     )

--- a/src/apolo_app_types/protocols/vscode.py
+++ b/src/apolo_app_types/protocols/vscode.py
@@ -15,7 +15,7 @@ from apolo_app_types.protocols.common.storage import (
     MountPath,
     StorageMounts,
 )
-from apolo_app_types.protocols.mlflow import MLFlowAppOutputs
+from apolo_app_types.protocols.mlflow import MLFlowTrackingServerURL
 
 
 class VSCodeInputs(AppInputsDeployer):
@@ -95,7 +95,7 @@ class VSCodeAppInputs(AppInputs):
             description=("Network settings for the application."),
         ).as_json_schema_extra(),
     )
-    mlflow_integration: MLFlowAppOutputs | None = Field(
+    mlflow_integration: MLFlowTrackingServerURL | None = Field(
         default=None,
         json_schema_extra=SchemaExtraMetadata(
             title="MLFlow Integration",


### PR DESCRIPTION
# What this PR does

- Introduces new class that ServiceAPI has both `internal` and `external` urls of a service as attributes.
- Modifies MLFlow app output types with new class
- Modifies Jupyter and VSCode chart value generator to use new mlflow output



## Examples

The `ServiceAPI` class takes a generic type as input, so it can function with `HttpApi`, `RestApi` or `GrpcApi`, like so:

```python
class NewType:
    web_app_url : ServiceAPI[HttpApi] = Field(ServiceAPI[HttpApi], ...)
    api_url : ServiceAPI[RestApi] = Field(ServiceAPI[HttpApi], ...)
```

and it will generate the correct reference in JsonSchema.

