### PR TITLE
Refactor default storage for Jupyter

### DIFF
--- a/src/apolo_app_types/helm/apps/vscode.py
+++ b/src/apolo_app_types/helm/apps/vscode.py
@@ -8,7 +8,6 @@ from apolo_app_types.helm.apps.base import BaseChartValueProcessor
 from apolo_app_types.helm.apps.custom_deployment import (
     CustomDeploymentChartValueProcessor,
 )
-from apolo_app_types.helm.utils.storage import get_app_data_files_relative_path_url
 from apolo_app_types.protocols.common import Container, Env, StorageMounts
 from apolo_app_types.protocols.common.health_check import (
     HealthCheck,
@@ -25,7 +24,7 @@ from apolo_app_types.protocols.common.storage import (
     MountPath,
 )
 from apolo_app_types.protocols.custom_deployment import NetworkingConfig
-from apolo_app_types.protocols.vscode import VSCodeAppInputs
+from apolo_app_types.protocols.vscode import _VSCODE_DEFAULTS, VSCodeAppInputs
 
 
 class VSCodeChartValueProcessor(BaseChartValueProcessor[VSCodeAppInputs]):
@@ -39,15 +38,8 @@ class VSCodeChartValueProcessor(BaseChartValueProcessor[VSCodeAppInputs]):
 
     def _get_default_code_storage_mount(self) -> ApoloFilesMount:
         return ApoloFilesMount(
-            storage_uri=ApoloFilesPath(
-                path=str(
-                    get_app_data_files_relative_path_url(
-                        app_type_name="vscode", app_name="vscode-app"
-                    )
-                    / "code"
-                )
-            ),
-            mount_path=MountPath(path="/home/coder/project"),
+            storage_uri=ApoloFilesPath(path=_VSCODE_DEFAULTS["storage"]),
+            mount_path=MountPath(path=_VSCODE_DEFAULTS["mount"]),
             mode=ApoloMountMode(mode=ApoloMountModes.RW),
         )
 

--- a/src/apolo_app_types/protocols/vscode.py
+++ b/src/apolo_app_types/protocols/vscode.py
@@ -1,6 +1,7 @@
 from pydantic import ConfigDict, Field
 
 from apolo_app_types import AppInputs, AppOutputs
+from apolo_app_types.helm.utils.storage import get_app_data_files_relative_path_url
 from apolo_app_types.protocols.common import AppInputsDeployer, AppOutputsDeployer
 from apolo_app_types.protocols.common.abc_ import AbstractAppFieldType
 from apolo_app_types.protocols.common.networking import RestAPI
@@ -11,6 +12,17 @@ from apolo_app_types.protocols.common.storage import (
     StorageMounts,
 )
 from apolo_app_types.protocols.mlflow import MLFlowTrackingServerURL
+
+
+_VSCODE_DEFAULTS = {
+    "storage": str(
+        get_app_data_files_relative_path_url(
+            app_type_name="vscode", app_name="vscode-app"
+        )
+        / "code"
+    ),
+    "mount": "/home/coder/project",
+}
 
 
 class VSCodeInputs(AppInputsDeployer):
@@ -53,7 +65,8 @@ class VSCodeSpecificAppInputs(AbstractAppFieldType):
             title="Override Default Storage Mounts",
             description=(
                 "Override Apolo Files mount within the application workloads. "
-                "If not set, Apolo will automatically assign a mount to the storage."
+                "If not set, Apolo will automatically mount "
+                f'"{_VSCODE_DEFAULTS["storage"]}" to "{_VSCODE_DEFAULTS["mount"]}"'
             ),
         ).as_json_schema_extra(),
     )


### PR DESCRIPTION
- Replaced default storage for Jupyter with a `override default storage` field - no more nested defaults
- Added the default mount values in the descriptions for Jupyter and VSCode

![image](https://github.com/user-attachments/assets/033bbcca-91d6-4f07-9553-fcffe785cf68)
