### PR TITLE
Remove custom PVC name support from MLFlow SQLite configuration

### DIFF
--- a/src/apolo_app_types/helm/apps/mlflow.py
+++ b/src/apolo_app_types/helm/apps/mlflow.py
@@ -27,7 +27,6 @@ from apolo_app_types.protocols.custom_deployment import (
 from apolo_app_types.protocols.mlflow import (
     MLFlowAppInputs,
     MLFlowMetadataPostgres,
-    MLFlowMetadataSQLite,
 )
 
 
@@ -83,8 +82,7 @@ class MLFlowChartValueProcessor(BaseChartValueProcessor[MLFlowAppInputs]):
                 raise ValueError(error_msg)
             backend_uri = input_.metadata_storage.postgres_uri.uri
             use_sqlite = False
-        elif isinstance(input_.metadata_storage, MLFlowMetadataSQLite):
-            pvc_name = input_.metadata_storage.pvc_name
+
         if use_sqlite:
             backend_uri = "sqlite:///mlflow-data/mlflow.db"
 

--- a/src/apolo_app_types/protocols/mlflow.py
+++ b/src/apolo_app_types/protocols/mlflow.py
@@ -35,13 +35,6 @@ class MLFlowMetadataSQLite(AbstractAppFieldType):
             ),
         ).as_json_schema_extra(),
     )
-    pvc_name: str = Field(
-        default="mlflow-sqlite-storage",
-        json_schema_extra=SchemaExtraMetadata(
-            description="Specify the name of the PVC claim to store local DB.",
-            title="PVC Name",
-        ).as_json_schema_extra(),
-    )
 
 
 MLFlowMetaStorage = MLFlowMetadataSQLite | MLFlowMetadataPostgres

--- a/tests/unit/mlflow/test_mlflow_input_generation.py
+++ b/tests/unit/mlflow/test_mlflow_input_generation.py
@@ -116,45 +116,6 @@ async def test_values_mlflow_generation_sqlite_explicit_no_pvc_name(
 
 
 @pytest.mark.asyncio
-async def test_values_mlflow_generation_sqlite_explicit_custom_pvc_name(
-    setup_clients, mock_get_preset_cpu
-):
-    """
-    Test that MLFlow uses the custom PVC name when SQLite is chosen
-    and a pvc_name is provided.
-    """
-    custom_pvc_name = "my-custom-pvc"
-    input_data = MLFlowAppInputs(
-        preset=Preset(name="cpu-small"),
-        ingress_http=IngressHttp(clusterName="test"),
-        metadata_storage=MLFlowMetadataSQLite(pvc_name=custom_pvc_name),
-        artifact_store=ApoloFilesPath(path="storage://foo/bar/baz"),
-    )
-
-    helm_args, helm_params = await app_type_to_vals(
-        input_=input_data,
-        apolo_client=setup_clients,
-        app_type=AppType.MLFlow,
-        app_name="my-mlflow",
-        namespace=DEFAULT_NAMESPACE,
-        app_secrets_name=APP_SECRETS_NAME,
-    )
-
-    # Assert SQLite URI
-    env_vars = helm_params["container"]["env"]
-    tracking_env = next(
-        (e for e in env_vars if e["name"] == "MLFLOW_TRACKING_URI"), None
-    )
-    assert tracking_env["value"] == "sqlite:///mlflow-data/mlflow.db"
-
-    # Assert custom PVC name
-    assert (
-        helm_params["volumes"][0]["persistentVolumeClaim"]["claimName"]
-        == custom_pvc_name
-    )
-
-
-@pytest.mark.asyncio
 async def test_values_mlflow_generation_postgres_uri(
     setup_clients, mock_get_preset_cpu
 ):


### PR DESCRIPTION
Removed custom PVC name from MLFlow inputs because it is a low level configuration of our K8s cluster that customers do not need to have control over and makes for a confusing installation form.

![image](https://github.com/user-attachments/assets/7ed6ae21-19ab-4534-a6a6-551252614fa2)
