### PR TITLE
feat: add meta_type for integration in ContainerImage, JupyterAppInputs, and VSCodeAppInputs

### DIFF
--- a/src/apolo_app_types/protocols/common/containers.py
+++ b/src/apolo_app_types/protocols/common/containers.py
@@ -1,7 +1,10 @@
 from pydantic import ConfigDict, Field
 
 from apolo_app_types.protocols.common.abc_ import AbstractAppFieldType
-from apolo_app_types.protocols.common.schema_extra import SchemaExtraMetadata
+from apolo_app_types.protocols.common.schema_extra import (
+    SchemaExtraMetadata,
+    SchemaMetaType,
+)
 from apolo_app_types.protocols.dockerhub import DockerConfigModel
 
 
@@ -32,5 +35,6 @@ class ContainerImage(AbstractAppFieldType):
         json_schema_extra=SchemaExtraMetadata(
             title="ImagePullSecrets for DockerHub",
             description="ImagePullSecrets for DockerHub",
+            meta_type=SchemaMetaType.INTEGRATION,
         ).as_json_schema_extra(),
     )

--- a/src/apolo_app_types/protocols/jupyter.py
+++ b/src/apolo_app_types/protocols/jupyter.py
@@ -12,6 +12,7 @@ from apolo_app_types.protocols.common import (
 )
 from apolo_app_types.protocols.common.abc_ import AbstractAppFieldType
 from apolo_app_types.protocols.common.networking import RestAPI
+from apolo_app_types.protocols.common.schema_extra import SchemaMetaType
 from apolo_app_types.protocols.common.storage import (
     ApoloFilesMount,
     StorageMounts,
@@ -116,6 +117,7 @@ class JupyterAppInputs(AppInputs):
             title="MLFlow Integration",
             description="Enable integration with MLFlow for"
             " experiment tracking and model management.",
+            meta_type=SchemaMetaType.INTEGRATION,
         ).as_json_schema_extra(),
     )
 

--- a/src/apolo_app_types/protocols/vscode.py
+++ b/src/apolo_app_types/protocols/vscode.py
@@ -6,7 +6,10 @@ from apolo_app_types.protocols.common import AppInputsDeployer, AppOutputsDeploy
 from apolo_app_types.protocols.common.abc_ import AbstractAppFieldType
 from apolo_app_types.protocols.common.networking import RestAPI
 from apolo_app_types.protocols.common.preset import Preset
-from apolo_app_types.protocols.common.schema_extra import SchemaExtraMetadata
+from apolo_app_types.protocols.common.schema_extra import (
+    SchemaExtraMetadata,
+    SchemaMetaType,
+)
 from apolo_app_types.protocols.common.storage import (
     ApoloFilesMount,
     StorageMounts,
@@ -97,6 +100,7 @@ class VSCodeAppInputs(AppInputs):
                 "MLFlow integration settings for the application. "
                 "If not set, MLFlow integration will not be enabled."
             ),
+            meta_type=SchemaMetaType.INTEGRATION,
         ).as_json_schema_extra(),
     )
 


### PR DESCRIPTION
This pull request introduces the `SchemaMetaType` enum to enhance schema metadata functionality and applies it across multiple protocol files. The key changes involve importing `SchemaMetaType` where necessary and updating schema metadata definitions to include the new `meta_type` field.

### Enhancements to schema metadata:

* **Addition of `SchemaMetaType` Import:**
  - Imported `SchemaMetaType` in `src/apolo_app_types/protocols/common/containers.py`, `src/apolo_app_types/protocols/jupyter.py`, and `src/apolo_app_types/protocols/vscode.py` to enable its usage in schema definitions. [[1]](diffhunk://#diff-7c9904a82bdf8f277ac0952c376b8f23c00b3675107b5b6a7dd6e4105434ec0aL4-R7) [[2]](diffhunk://#diff-c91feda5f5a239e6dabad9980a851c4189bbae65251a23e12ef255f18225fe36R15) [[3]](diffhunk://#diff-c15a7f26c7a8df8ecef987ec3a965cf0e1589f9efef06ddb8298cca0bbc56f24L9-R12)

* **Updates to Metadata Definitions:**
  - Added the `meta_type=SchemaMetaType.INTEGRATION` field to the `json_schema_extra` metadata in the `ContainerImage` class in `src/apolo_app_types/protocols/common/containers.py`.
  - Updated the `json_schema_extra` metadata in the `JupyterAppInputs` class in `src/apolo_app_types/protocols/jupyter.py` to include `meta_type=SchemaMetaType.INTEGRATION`.
  - Modified the `json_schema_extra` metadata in the `VSCodeAppInputs` class in `src/apolo_app_types/protocols/vscode.py` to include `meta_type=SchemaMetaType.INTEGRATION`.