### PR TITLE
Jupyter new image

### DIFF
--- a/src/apolo_app_types/protocols/jupyter.py
+++ b/src/apolo_app_types/protocols/jupyter.py
@@ -27,7 +27,7 @@ _JUPYTER_DEFAULTS = {
         )
         / "code"
     ),
-    "mount": "/root/notebooks",
+    "mount": "/home/jovyan",
 }
 
 

--- a/src/apolo_app_types/protocols/jupyter.py
+++ b/src/apolo_app_types/protocols/jupyter.py
@@ -31,6 +31,11 @@ _JUPYTER_DEFAULTS = {
 }
 
 
+class JupyterImage(str, Enum):
+    BASE_NOTEBOOK = "quay.io/jupyter/base-notebook:python-3.12"
+    PYTORCH_NOTEBOOK = "quay.io/jupyter/pytorch-notebook:cuda12-python-3.12"
+
+
 class JupyterTypes(str, Enum):
     LAB = "lab"
     NOTEBOOK = "notebook"
@@ -69,12 +74,12 @@ class JupyterSpecificAppInputs(AbstractAppFieldType):
             description="Configure the Jupyter App.",
         ).as_json_schema_extra(),
     )
-    jupyter_type: JupyterTypes = Field(
-        default=JupyterTypes.LAB,
-        description=(
-            "Choose whether the Jupyter server should run in 'lab' or 'notebook' mode."
-        ),
-        title="Jupyter server type",
+    container_image: JupyterImage = Field(
+        default=JupyterImage.BASE_NOTEBOOK,
+        json_schema_extra=SchemaExtraMetadata(
+            description="Container image for the Jupyter application.",
+            title="Container Image",
+        ).as_json_schema_extra(),
     )
     override_code_storage_mount: ApoloFilesMount | None = Field(
         default=None,

--- a/src/apolo_app_types/protocols/jupyter.py
+++ b/src/apolo_app_types/protocols/jupyter.py
@@ -28,7 +28,7 @@ _JUPYTER_DEFAULTS = {
         )
         / "code"
     ),
-    "mount": "/home/jovyan",
+    "mount": "/root/notebooks",
 }
 
 
@@ -141,7 +141,7 @@ class JupyterSpecificAppInputs(AbstractAppFieldType):
             description=(
                 "Override Apolo Files mount within the application workloads. "
                 "If not set, Apolo will automatically mount "
-                f'"{_JUPYTER_DEFAULTS["storage"]}" to "{_JUPYTER_DEFAULTS["mount"]}"'
+                f'"{_JUPYTER_DEFAULTS["storage"]}" to "{_JUPYTER_DEFAULTS["mount"]}".'
             ),
         ).as_json_schema_extra(),
     )

--- a/tests/unit/jupyter/test_jupyter_input_generation.py
+++ b/tests/unit/jupyter/test_jupyter_input_generation.py
@@ -55,7 +55,7 @@ async def test_jupyter_values_generation(setup_clients):
         == f"storage://{DEFAULT_CLUSTER_NAME}/{DEFAULT_ORG_NAME}/{DEFAULT_PROJECT_NAME}/"
         f".apps/jupyter/jupyter-app/code"
     )
-    assert parsed_storage[0]["mount_path"] == "/root/notebooks"
+    assert parsed_storage[0]["mount_path"] == "/home/jovyan"
     assert parsed_storage[0]["mount_mode"] == "rw"
 
     pod_labels = helm_params.get("podLabels", {})

--- a/tests/unit/jupyter/test_jupyter_input_generation.py
+++ b/tests/unit/jupyter/test_jupyter_input_generation.py
@@ -8,7 +8,6 @@ from apolo_app_types.protocols.common import Preset
 from apolo_app_types.protocols.jupyter import (
     JupyterAppInputs,
     JupyterSpecificAppInputs,
-    JupyterTypes,
 )
 
 from tests.unit.constants import (
@@ -25,7 +24,6 @@ async def test_jupyter_values_generation(setup_clients):
         input_=JupyterAppInputs(
             preset=Preset(name="cpu-small"),
             jupyter_specific=JupyterSpecificAppInputs(
-                jupyter_type=JupyterTypes.LAB,
                 http_auth=False,
             ),
         ),
@@ -36,8 +34,8 @@ async def test_jupyter_values_generation(setup_clients):
         app_secrets_name=APP_SECRETS_NAME,
     )
     assert helm_params["image"] == {
-        "repository": "ghcr.io/neuro-inc/base",
-        "tag": "v25.3.0-runtime",
+        "repository": "quay.io/jupyter/base-notebook",
+        "tag": "python-3.12",
     }
 
     assert helm_params["service"] == {

--- a/tests/unit/jupyter/test_jupyter_input_generation.py
+++ b/tests/unit/jupyter/test_jupyter_input_generation.py
@@ -2,11 +2,16 @@ import json
 
 import pytest
 
+from apolo_app_types import Container, ContainerImage
 from apolo_app_types.app_types import AppType
+from apolo_app_types.helm.apps.jupyter import JupyterChartValueProcessor
 from apolo_app_types.inputs.args import app_type_to_vals
 from apolo_app_types.protocols.common import Preset
 from apolo_app_types.protocols.jupyter import (
+    CustomImage,
+    DefaultContainer,
     JupyterAppInputs,
+    JupyterImage,
     JupyterSpecificAppInputs,
 )
 
@@ -34,8 +39,130 @@ async def test_jupyter_values_generation(setup_clients):
         app_secrets_name=APP_SECRETS_NAME,
     )
     assert helm_params["image"] == {
-        "repository": "quay.io/jupyter/base-notebook",
-        "tag": "python-3.12",
+        "repository": "ghcr.io/neuro-inc/base",
+        "tag": "v25.3.0-runtime",
+    }
+
+    assert helm_params["service"] == {
+        "enabled": True,
+        "ports": [{"name": "http", "containerPort": 8888}],
+    }
+
+    assert "podAnnotations" in helm_params
+    annotations = helm_params["podAnnotations"]
+    assert "platform.apolo.us/inject-storage" in annotations
+
+    storage_json = annotations["platform.apolo.us/inject-storage"]
+    parsed_storage = json.loads(storage_json)
+
+    assert (
+        parsed_storage[0]["storage_uri"]
+        == f"storage://{DEFAULT_CLUSTER_NAME}/{DEFAULT_ORG_NAME}/{DEFAULT_PROJECT_NAME}/"
+        f".apps/jupyter/jupyter-app/code"
+    )
+    assert parsed_storage[0]["mount_path"] == "/home/jovyan"
+    assert parsed_storage[0]["mount_mode"] == "rw"
+
+    pod_labels = helm_params.get("podLabels", {})
+    assert pod_labels.get("platform.apolo.us/inject-storage") == "true"
+
+
+@pytest.mark.asyncio
+async def test_jupyter_community_images_values_generation(setup_clients):
+    helm_args, helm_params = await app_type_to_vals(
+        input_=JupyterAppInputs(
+            preset=Preset(name="cpu-small"),
+            jupyter_specific=JupyterSpecificAppInputs(
+                http_auth=False,
+                container_settings=DefaultContainer(
+                    container_image=JupyterImage.BASE_NOTEBOOK
+                ),
+            ),
+        ),
+        apolo_client=setup_clients,
+        app_type=AppType.Jupyter,
+        app_name="jupyter-app",
+        namespace="default-namespace",
+        app_secrets_name=APP_SECRETS_NAME,
+    )
+    image, tag = JupyterImage.BASE_NOTEBOOK.value.split(":")
+    assert helm_params["image"] == {
+        "repository": image,
+        "tag": tag,
+    }
+    mount_path = str(JupyterChartValueProcessor._default_code_mount_path)
+    jupyter_port = JupyterChartValueProcessor._jupyter_port
+    assert helm_params["container"] == {
+        "command": None,
+        "args": [
+            "start-notebook.py",
+            f"--ServerApp.root_dir={mount_path}",
+            "--IdentityProvider.auth_enabled=false",
+            "--PasswordIdentityProvider.password_required=false",
+            f"--ServerApp.port={jupyter_port}",
+            "--ServerApp.ip=0.0.0.0",
+            f"--ServerApp.default_url={mount_path}",
+        ],
+        "env": [],
+    }
+
+    assert helm_params["service"] == {
+        "enabled": True,
+        "ports": [{"name": "http", "containerPort": 8888}],
+    }
+
+    assert "podAnnotations" in helm_params
+    annotations = helm_params["podAnnotations"]
+    assert "platform.apolo.us/inject-storage" in annotations
+
+    storage_json = annotations["platform.apolo.us/inject-storage"]
+    parsed_storage = json.loads(storage_json)
+
+    assert (
+        parsed_storage[0]["storage_uri"]
+        == f"storage://{DEFAULT_CLUSTER_NAME}/{DEFAULT_ORG_NAME}/{DEFAULT_PROJECT_NAME}/"
+        f".apps/jupyter/jupyter-app/code"
+    )
+    assert parsed_storage[0]["mount_path"] == "/home/jovyan"
+    assert parsed_storage[0]["mount_mode"] == "rw"
+
+    pod_labels = helm_params.get("podLabels", {})
+    assert pod_labels.get("platform.apolo.us/inject-storage") == "true"
+
+
+@pytest.mark.asyncio
+async def test_jupyter_custom_image_values_generation(setup_clients):
+    helm_args, helm_params = await app_type_to_vals(
+        input_=JupyterAppInputs(
+            preset=Preset(name="cpu-small"),
+            jupyter_specific=JupyterSpecificAppInputs(
+                http_auth=False,
+                container_settings=CustomImage(
+                    container_image=ContainerImage(
+                        repository="image-name",
+                        tag="latest",
+                    ),
+                    container_config=Container(
+                        command=["start-notebook.sh"],
+                        args=["--NotebookApp.token=''"],
+                    ),
+                ),
+            ),
+        ),
+        apolo_client=setup_clients,
+        app_type=AppType.Jupyter,
+        app_name="jupyter-app",
+        namespace="default-namespace",
+        app_secrets_name=APP_SECRETS_NAME,
+    )
+    assert helm_params["image"] == {
+        "repository": "image-name",
+        "tag": "latest",
+    }
+    assert helm_params["container"] == {
+        "command": ["start-notebook.sh"],
+        "args": ["--NotebookApp.token=''"],
+        "env": [],
     }
 
     assert helm_params["service"] == {

--- a/tests/unit/jupyter/test_jupyter_input_generation.py
+++ b/tests/unit/jupyter/test_jupyter_input_generation.py
@@ -8,6 +8,7 @@ from apolo_app_types.helm.apps.jupyter import JupyterChartValueProcessor
 from apolo_app_types.inputs.args import app_type_to_vals
 from apolo_app_types.protocols.common import Preset
 from apolo_app_types.protocols.jupyter import (
+    _JUPYTER_DEFAULTS,
     CustomImage,
     DefaultContainer,
     JupyterAppInputs,
@@ -60,7 +61,7 @@ async def test_jupyter_values_generation(setup_clients):
         == f"storage://{DEFAULT_CLUSTER_NAME}/{DEFAULT_ORG_NAME}/{DEFAULT_PROJECT_NAME}/"
         f".apps/jupyter/jupyter-app/code"
     )
-    assert parsed_storage[0]["mount_path"] == "/home/jovyan"
+    assert parsed_storage[0]["mount_path"] == "/root/notebooks"
     assert parsed_storage[0]["mount_mode"] == "rw"
 
     pod_labels = helm_params.get("podLabels", {})
@@ -90,7 +91,7 @@ async def test_jupyter_community_images_values_generation(setup_clients):
         "repository": image,
         "tag": tag,
     }
-    mount_path = str(JupyterChartValueProcessor._default_code_mount_path)
+    mount_path = "/home/jovyan"
     jupyter_port = JupyterChartValueProcessor._jupyter_port
     assert helm_params["container"] == {
         "command": None,
@@ -123,7 +124,7 @@ async def test_jupyter_community_images_values_generation(setup_clients):
         == f"storage://{DEFAULT_CLUSTER_NAME}/{DEFAULT_ORG_NAME}/{DEFAULT_PROJECT_NAME}/"
         f".apps/jupyter/jupyter-app/code"
     )
-    assert parsed_storage[0]["mount_path"] == "/home/jovyan"
+    assert parsed_storage[0]["mount_path"] == mount_path
     assert parsed_storage[0]["mount_mode"] == "rw"
 
     pod_labels = helm_params.get("podLabels", {})
@@ -182,7 +183,7 @@ async def test_jupyter_custom_image_values_generation(setup_clients):
         == f"storage://{DEFAULT_CLUSTER_NAME}/{DEFAULT_ORG_NAME}/{DEFAULT_PROJECT_NAME}/"
         f".apps/jupyter/jupyter-app/code"
     )
-    assert parsed_storage[0]["mount_path"] == "/home/jovyan"
+    assert parsed_storage[0]["mount_path"] == _JUPYTER_DEFAULTS["mount"]
     assert parsed_storage[0]["mount_mode"] == "rw"
 
     pod_labels = helm_params.get("podLabels", {})


### PR DESCRIPTION
# What this PR does

It aims to replace the current Apolo-maintained image for Jupyter with a newer, official [community maintained image](https://jupyter-docker-stacks.readthedocs.io/en/latest/index.html).

# Why

Our current image size is too large and it takes several minutes for a Jupyter instance to start because we keep pulling the image. We could also change the `imagePullPolicy`, but I think we could try to use a open source image.

Also, this image contains the newer version of Jupyter Server, which is replacing the old `NotebookApp` that we were using.

# Other additions

- Added an option to choose the image from a small list of 2 
  - `quay.io/jupyter/base-notebook:python-3.12` which is very lightweight and doesn't contain any DS libs
  - `quay.io/jupyter/pytorch-notebook:cuda12-python-3.12` which contains many DS libs, pytorch and CUDA support
- Removed the options to use Jupyter **Notebook** because it is also being deprecated by the Jupyter project in favor or Jupyter **Lab**