### PR TITLE
Update output generation to use app instance id from k8s

### DIFF
--- a/charts/hook/templates/post-install.yaml
+++ b/charts/hook/templates/post-install.yaml
@@ -22,3 +22,8 @@ spec:
         - "update-outputs"
         - {{ include "filterNonEmptyAndConvertToJson" .Values | squote }}
         imagePullPolicy: {{ .Values.appTypesImage.pullPolicy }}
+        env:
+        - name: K8S_INSTANCE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/instance']

--- a/src/apolo_app_types/outputs/common.py
+++ b/src/apolo_app_types/outputs/common.py
@@ -3,6 +3,9 @@ from apolo_app_types.outputs.utils.ingress import get_ingress_host_port
 from apolo_app_types.protocols.common import RestAPI
 
 
+INSTANCE_LABEL = "app.kubernetes.io/instance"
+
+
 async def get_internal_external_web_urls(
     labels: dict[str, str],
 ) -> tuple[RestAPI | None, RestAPI | None]:

--- a/src/apolo_app_types/outputs/custom_deployment.py
+++ b/src/apolo_app_types/outputs/custom_deployment.py
@@ -9,10 +9,15 @@ logger = logging.getLogger()
 
 
 async def get_custom_deployment_outputs(
-    helm_values: dict[str, t.Any], labels: dict[str, str] | None = None
+    helm_values: dict[str, t.Any],
+    app_instance_id: str,
+    labels: dict[str, str] | None = None,
 ) -> dict[str, t.Any]:
     if not labels:
-        labels = {"application": "custom-deployment"}
+        labels = {
+            "application": "custom-deployment",
+            "app.kubernetes.io/instance": app_instance_id,
+        }
     internal_web_app_url, external_web_app_url = await get_internal_external_web_urls(
         labels
     )

--- a/src/apolo_app_types/outputs/custom_deployment.py
+++ b/src/apolo_app_types/outputs/custom_deployment.py
@@ -2,7 +2,10 @@ import logging
 import typing as t
 
 from apolo_app_types import CustomDeploymentOutputs
-from apolo_app_types.outputs.common import get_internal_external_web_urls
+from apolo_app_types.outputs.common import (
+    INSTANCE_LABEL,
+    get_internal_external_web_urls,
+)
 
 
 logger = logging.getLogger()
@@ -16,7 +19,7 @@ async def get_custom_deployment_outputs(
     if not labels:
         labels = {
             "application": "custom-deployment",
-            "app.kubernetes.io/instance": app_instance_id,
+            INSTANCE_LABEL: app_instance_id,
         }
     internal_web_app_url, external_web_app_url = await get_internal_external_web_urls(
         labels

--- a/src/apolo_app_types/outputs/dify.py
+++ b/src/apolo_app_types/outputs/dify.py
@@ -8,8 +8,10 @@ from apolo_app_types.protocols.dify import DifyAppOutputs, DifySpecificOutputs
 
 async def get_dify_outputs(
     helm_values: dict[str, t.Any],
+    app_instance_id: str,
 ) -> dict[str, t.Any]:
-    api_labels = {"application": "dify", "component": "api"}
+    main_labels = {"application": "dify", "app.kubernetes.io/instance": app_instance_id}
+    api_labels = {**main_labels, "component": "api"}
     api_internal_host, api_internal_port = await get_service_host_port(
         match_labels=api_labels
     )
@@ -21,7 +23,7 @@ async def get_dify_outputs(
             base_path="/",
             protocol="http",
         )
-    web_labels = {"application": "dify", "component": "web"}
+    web_labels = {**main_labels, "component": "web"}
     web_internal_host, web_internal_port = await get_service_host_port(
         match_labels=web_labels
     )
@@ -33,8 +35,7 @@ async def get_dify_outputs(
             base_path="/",
             protocol="http",
         )
-    match_labels = {"application": "dify"}
-    host_port = await get_ingress_host_port(match_labels=match_labels)
+    host_port = await get_ingress_host_port(match_labels=main_labels)
     external_web_app_url = None
     if host_port:
         host, port = host_port

--- a/src/apolo_app_types/outputs/dify.py
+++ b/src/apolo_app_types/outputs/dify.py
@@ -1,6 +1,7 @@
 import typing as t
 
 from apolo_app_types.clients.kube import get_service_host_port
+from apolo_app_types.outputs.common import INSTANCE_LABEL
 from apolo_app_types.outputs.utils.ingress import get_ingress_host_port
 from apolo_app_types.protocols.common import RestAPI
 from apolo_app_types.protocols.dify import DifyAppOutputs, DifySpecificOutputs
@@ -10,7 +11,7 @@ async def get_dify_outputs(
     helm_values: dict[str, t.Any],
     app_instance_id: str,
 ) -> dict[str, t.Any]:
-    main_labels = {"application": "dify", "app.kubernetes.io/instance": app_instance_id}
+    main_labels = {"application": "dify", INSTANCE_LABEL: app_instance_id}
     api_labels = {**main_labels, "component": "api"}
     api_internal_host, api_internal_port = await get_service_host_port(
         match_labels=api_labels

--- a/src/apolo_app_types/outputs/dockerhub.py
+++ b/src/apolo_app_types/outputs/dockerhub.py
@@ -9,7 +9,9 @@ from apolo_app_types import DockerConfigModel, DockerHubOutputs
 logger = logging.getLogger()
 
 
-async def get_dockerhub_outputs(helm_values: dict[str, t.Any]) -> dict[str, t.Any]:
+async def get_dockerhub_outputs(
+    helm_values: dict[str, t.Any], app_instance_id: str
+) -> dict[str, t.Any]:
     user = helm_values["job"]["args"]["registry_user"]
     secret = helm_values["job"]["args"]["registry_secret"]
     auth64 = base64.b64encode(f"{user}:{secret}".encode())

--- a/src/apolo_app_types/outputs/fooocus.py
+++ b/src/apolo_app_types/outputs/fooocus.py
@@ -6,8 +6,9 @@ from apolo_app_types.protocols.fooocus import FooocusAppOutputs
 
 async def get_fooocus_outputs(
     helm_values: dict[str, t.Any],
+    app_instance_id: str,
 ) -> dict[str, t.Any]:
-    labels = {"application": "fooocus"}
+    labels = {"application": "fooocus", "app.kubernetes.io/instance": app_instance_id}
     internal_web_app_url, external_web_app_url = await get_internal_external_web_urls(
         labels
     )

--- a/src/apolo_app_types/outputs/fooocus.py
+++ b/src/apolo_app_types/outputs/fooocus.py
@@ -1,6 +1,9 @@
 import typing as t
 
-from apolo_app_types.outputs.common import get_internal_external_web_urls
+from apolo_app_types.outputs.common import (
+    INSTANCE_LABEL,
+    get_internal_external_web_urls,
+)
 from apolo_app_types.protocols.fooocus import FooocusAppOutputs
 
 
@@ -8,7 +11,7 @@ async def get_fooocus_outputs(
     helm_values: dict[str, t.Any],
     app_instance_id: str,
 ) -> dict[str, t.Any]:
-    labels = {"application": "fooocus", "app.kubernetes.io/instance": app_instance_id}
+    labels = {"application": "fooocus", INSTANCE_LABEL: app_instance_id}
     internal_web_app_url, external_web_app_url = await get_internal_external_web_urls(
         labels
     )

--- a/src/apolo_app_types/outputs/huggingface_cache.py
+++ b/src/apolo_app_types/outputs/huggingface_cache.py
@@ -11,7 +11,9 @@ from apolo_app_types.protocols.huggingface_cache import (
 logger = logging.getLogger(__name__)
 
 
-async def get_app_outputs(helm_values: dict[str, t.Any]) -> dict[str, t.Any]:
+async def get_app_outputs(
+    helm_values: dict[str, t.Any], app_instance_id: str
+) -> dict[str, t.Any]:
     storage_uri = helm_values["storage_uri"]
     return HuggingFaceCacheOutputs(
         cache_config=HuggingFaceCache(

--- a/src/apolo_app_types/outputs/jupyter.py
+++ b/src/apolo_app_types/outputs/jupyter.py
@@ -2,7 +2,10 @@ import logging
 import typing as t
 
 from apolo_app_types import JupyterAppOutputs
-from apolo_app_types.outputs.common import get_internal_external_web_urls
+from apolo_app_types.outputs.common import (
+    INSTANCE_LABEL,
+    get_internal_external_web_urls,
+)
 
 
 logger = logging.getLogger()
@@ -11,7 +14,7 @@ logger = logging.getLogger()
 async def get_jupyter_outputs(
     helm_values: dict[str, t.Any], app_instance_id: str
 ) -> dict[str, t.Any]:
-    labels = {"application": "jupyter", "app.kubernetes.io/instance": app_instance_id}
+    labels = {"application": "jupyter", INSTANCE_LABEL: app_instance_id}
     internal_web_app_url, external_web_app_url = await get_internal_external_web_urls(
         labels
     )

--- a/src/apolo_app_types/outputs/jupyter.py
+++ b/src/apolo_app_types/outputs/jupyter.py
@@ -9,10 +9,9 @@ logger = logging.getLogger()
 
 
 async def get_jupyter_outputs(
-    helm_values: dict[str, t.Any], labels: dict[str, str] | None = None
+    helm_values: dict[str, t.Any], app_instance_id: str
 ) -> dict[str, t.Any]:
-    if not labels:
-        labels = {"application": "jupyter"}
+    labels = {"application": "jupyter", "app.kubernetes.io/instance": app_instance_id}
     internal_web_app_url, external_web_app_url = await get_internal_external_web_urls(
         labels
     )

--- a/src/apolo_app_types/outputs/llm.py
+++ b/src/apolo_app_types/outputs/llm.py
@@ -6,6 +6,7 @@ from apolo_app_types import (
     VLLMOutputsV2,
 )
 from apolo_app_types.clients.kube import get_service_host_port
+from apolo_app_types.outputs.common import INSTANCE_LABEL
 from apolo_app_types.outputs.utils.ingress import get_ingress_host_port
 from apolo_app_types.outputs.utils.parsing import parse_cli_args
 from apolo_app_types.protocols.common.openai_compat import (
@@ -23,7 +24,7 @@ async def get_llm_inference_outputs(
     internal_host, internal_port = await get_service_host_port(
         match_labels={
             "application": "llm-inference",
-            "app.kubernetes.io/instance": app_instance_id,
+            INSTANCE_LABEL: app_instance_id,
         }
     )
     server_extra_args = helm_values.get("serverExtraArgs", [])

--- a/src/apolo_app_types/outputs/llm.py
+++ b/src/apolo_app_types/outputs/llm.py
@@ -17,9 +17,14 @@ from apolo_app_types.protocols.common.openai_compat import (
 logger = logging.getLogger()
 
 
-async def get_llm_inference_outputs(helm_values: dict[str, t.Any]) -> dict[str, t.Any]:
+async def get_llm_inference_outputs(
+    helm_values: dict[str, t.Any], app_instance_id: str
+) -> dict[str, t.Any]:
     internal_host, internal_port = await get_service_host_port(
-        match_labels={"application": "llm-inference"}
+        match_labels={
+            "application": "llm-inference",
+            "app.kubernetes.io/instance": app_instance_id,
+        }
     )
     server_extra_args = helm_values.get("serverExtraArgs", [])
     cli_args = parse_cli_args(server_extra_args)

--- a/src/apolo_app_types/outputs/mlflow.py
+++ b/src/apolo_app_types/outputs/mlflow.py
@@ -9,8 +9,9 @@ from apolo_app_types.protocols.common.networking import HttpApi, RestAPI, Servic
 
 async def get_mlflow_outputs(
     helm_values: dict[str, t.Any],
+    app_instance_id: str,
 ) -> dict[str, t.Any]:
-    labels = {"application": "mlflow"}
+    labels = {"application": "mlflow", "app.kubernetes.io/instance": app_instance_id}
     internal_web_app_url, external_web_app_url = await get_internal_external_web_urls(
         labels
     )

--- a/src/apolo_app_types/outputs/mlflow.py
+++ b/src/apolo_app_types/outputs/mlflow.py
@@ -2,7 +2,10 @@ import typing as t
 
 from apolo_app_types import MLFlowAppOutputs, MLFlowTrackingServerURL
 from apolo_app_types.clients.kube import get_service_host_port
-from apolo_app_types.outputs.common import get_internal_external_web_urls
+from apolo_app_types.outputs.common import (
+    INSTANCE_LABEL,
+    get_internal_external_web_urls,
+)
 from apolo_app_types.outputs.utils.ingress import get_ingress_host_port
 from apolo_app_types.protocols.common.networking import HttpApi, RestAPI, ServiceAPI
 
@@ -11,7 +14,7 @@ async def get_mlflow_outputs(
     helm_values: dict[str, t.Any],
     app_instance_id: str,
 ) -> dict[str, t.Any]:
-    labels = {"application": "mlflow", "app.kubernetes.io/instance": app_instance_id}
+    labels = {"application": "mlflow", INSTANCE_LABEL: app_instance_id}
     internal_web_app_url, external_web_app_url = await get_internal_external_web_urls(
         labels
     )

--- a/src/apolo_app_types/outputs/postgres.py
+++ b/src/apolo_app_types/outputs/postgres.py
@@ -71,6 +71,7 @@ def postgres_creds_from_kube_secret_data(
 
 async def get_postgres_outputs(
     helm_values: dict[str, t.Any],
+    app_instance_id: str,
 ) -> dict[str, t.Any]:
     for trial in range(1, MAX_SLEEP_SEC):
         logger.info("Trying to get postgres outputs")  # noqa: T201

--- a/src/apolo_app_types/outputs/privategpt.py
+++ b/src/apolo_app_types/outputs/privategpt.py
@@ -8,8 +8,12 @@ from apolo_app_types.protocols.private_gpt import PrivateGPTAppOutputs
 
 async def get_privategpt_outputs(
     helm_values: dict[str, t.Any],
+    app_instance_id: str,
 ) -> dict[str, t.Any]:
-    labels = {"application": "privategpt"}
+    labels = {
+        "application": "privategpt",
+        "app.kubernetes.io/instance": app_instance_id,
+    }
     internal_host, internal_port = await get_service_host_port(match_labels=labels)
     internal_web_app_url = None
     if internal_host:

--- a/src/apolo_app_types/outputs/privategpt.py
+++ b/src/apolo_app_types/outputs/privategpt.py
@@ -1,6 +1,7 @@
 import typing as t
 
 from apolo_app_types.clients.kube import get_service_host_port
+from apolo_app_types.outputs.common import INSTANCE_LABEL
 from apolo_app_types.outputs.utils.ingress import get_ingress_host_port
 from apolo_app_types.protocols.common import RestAPI
 from apolo_app_types.protocols.private_gpt import PrivateGPTAppOutputs
@@ -12,7 +13,7 @@ async def get_privategpt_outputs(
 ) -> dict[str, t.Any]:
     labels = {
         "application": "privategpt",
-        "app.kubernetes.io/instance": app_instance_id,
+        INSTANCE_LABEL: app_instance_id,
     }
     internal_host, internal_port = await get_service_host_port(match_labels=labels)
     internal_web_app_url = None

--- a/src/apolo_app_types/outputs/shell.py
+++ b/src/apolo_app_types/outputs/shell.py
@@ -6,8 +6,9 @@ from apolo_app_types.outputs.common import get_internal_external_web_urls
 
 async def get_shell_outputs(
     helm_values: dict[str, t.Any],
+    app_instance_id: str,
 ) -> dict[str, t.Any]:
-    labels = {"application": "shell"}
+    labels = {"application": "shell", "app.kubernetes.io/instance": app_instance_id}
     internal_web_app_url, external_web_app_url = await get_internal_external_web_urls(
         labels
     )

--- a/src/apolo_app_types/outputs/shell.py
+++ b/src/apolo_app_types/outputs/shell.py
@@ -1,14 +1,17 @@
 import typing as t
 
 from apolo_app_types import ShellAppOutputs
-from apolo_app_types.outputs.common import get_internal_external_web_urls
+from apolo_app_types.outputs.common import (
+    INSTANCE_LABEL,
+    get_internal_external_web_urls,
+)
 
 
 async def get_shell_outputs(
     helm_values: dict[str, t.Any],
     app_instance_id: str,
 ) -> dict[str, t.Any]:
-    labels = {"application": "shell", "app.kubernetes.io/instance": app_instance_id}
+    labels = {"application": "shell", INSTANCE_LABEL: app_instance_id}
     internal_web_app_url, external_web_app_url = await get_internal_external_web_urls(
         labels
     )

--- a/src/apolo_app_types/outputs/spark_job.py
+++ b/src/apolo_app_types/outputs/spark_job.py
@@ -7,5 +7,6 @@ logger = logging.getLogger()
 
 async def get_spark_job_outputs(
     helm_values: dict[str, t.Any],
+    app_instance_id: str,
 ) -> dict[str, t.Any]:
     return {}

--- a/src/apolo_app_types/outputs/stable_diffusion.py
+++ b/src/apolo_app_types/outputs/stable_diffusion.py
@@ -13,13 +13,16 @@ logger = logging.getLogger()
 
 async def get_stable_diffusion_outputs(
     helm_values: dict[str, t.Any],
+    app_instance_id: str,
 ) -> dict[str, t.Any]:
+    match_labels = {
+        "application": "stable-diffusion",
+        "app.kubernetes.io/instance": app_instance_id,
+    }
     internal_host, internal_port = await get_service_host_port(
-        match_labels={"application": "stable-diffusion"}
+        match_labels=match_labels
     )
-    ingress_host_port = await get_ingress_host_port(
-        match_labels={"application": "stable-diffusion"}
-    )
+    ingress_host_port = await get_ingress_host_port(match_labels=match_labels)
     if ingress_host_port:
         external_host = ingress_host_port[0]
     else:

--- a/src/apolo_app_types/outputs/stable_diffusion.py
+++ b/src/apolo_app_types/outputs/stable_diffusion.py
@@ -3,6 +3,7 @@ import typing as t
 
 from apolo_app_types import HuggingFaceModel
 from apolo_app_types.clients.kube import get_service_host_port
+from apolo_app_types.outputs.common import INSTANCE_LABEL
 from apolo_app_types.outputs.utils.ingress import get_ingress_host_port
 from apolo_app_types.protocols.common.networking import RestAPI
 from apolo_app_types.protocols.stable_diffusion import StableDiffusionOutputs
@@ -17,7 +18,7 @@ async def get_stable_diffusion_outputs(
 ) -> dict[str, t.Any]:
     match_labels = {
         "application": "stable-diffusion",
-        "app.kubernetes.io/instance": app_instance_id,
+        INSTANCE_LABEL: app_instance_id,
     }
     internal_host, internal_port = await get_service_host_port(
         match_labels=match_labels

--- a/src/apolo_app_types/outputs/superset.py
+++ b/src/apolo_app_types/outputs/superset.py
@@ -9,8 +9,9 @@ from apolo_app_types.protocols.superset import SupersetOutputs
 
 async def get_superset_outputs(
     helm_values: dict[str, t.Any],
+    app_instance_id: str,
 ) -> dict[str, t.Any]:
-    labels = {"application": "superset"}
+    labels = {"application": "superset", "app.kubernetes.io/instance": app_instance_id}
     internal_host, internal_port = await get_service_host_port(match_labels=labels)
     internal_web_app_url = None
     if internal_host:

--- a/src/apolo_app_types/outputs/superset.py
+++ b/src/apolo_app_types/outputs/superset.py
@@ -1,6 +1,7 @@
 import typing as t
 
 from apolo_app_types.clients.kube import get_service_host_port
+from apolo_app_types.outputs.common import INSTANCE_LABEL
 from apolo_app_types.outputs.utils.ingress import get_ingress_host_port
 from apolo_app_types.protocols.common import RestAPI, ServiceAPI
 from apolo_app_types.protocols.common.networking import HttpApi
@@ -11,7 +12,7 @@ async def get_superset_outputs(
     helm_values: dict[str, t.Any],
     app_instance_id: str,
 ) -> dict[str, t.Any]:
-    labels = {"application": "superset", "app.kubernetes.io/instance": app_instance_id}
+    labels = {"application": "superset", INSTANCE_LABEL: app_instance_id}
     internal_host, internal_port = await get_service_host_port(match_labels=labels)
     internal_web_app_url = None
     if internal_host:

--- a/src/apolo_app_types/outputs/tei.py
+++ b/src/apolo_app_types/outputs/tei.py
@@ -2,6 +2,7 @@ import typing as t
 
 from apolo_app_types import HuggingFaceModel
 from apolo_app_types.clients.kube import get_service_host_port
+from apolo_app_types.outputs.common import INSTANCE_LABEL
 from apolo_app_types.outputs.utils.ingress import get_ingress_host_port
 from apolo_app_types.protocols.common.openai_compat import OpenAICompatEmbeddingsAPI
 from apolo_app_types.protocols.text_embeddings import TextEmbeddingsInferenceAppOutputs
@@ -13,7 +14,7 @@ async def get_tei_outputs(
 ) -> dict[str, t.Any]:
     labels = {
         "application": "text-embeddings-inference",
-        "app.kubernetes.io/instance": app_instance_id,
+        INSTANCE_LABEL: app_instance_id,
     }
     internal_host, internal_port = await get_service_host_port(match_labels=labels)
     internal_api = None

--- a/src/apolo_app_types/outputs/tei.py
+++ b/src/apolo_app_types/outputs/tei.py
@@ -9,8 +9,12 @@ from apolo_app_types.protocols.text_embeddings import TextEmbeddingsInferenceApp
 
 async def get_tei_outputs(
     helm_values: dict[str, t.Any],
+    app_instance_id: str,
 ) -> dict[str, t.Any]:
-    labels = {"application": "text-embeddings-inference"}
+    labels = {
+        "application": "text-embeddings-inference",
+        "app.kubernetes.io/instance": app_instance_id,
+    }
     internal_host, internal_port = await get_service_host_port(match_labels=labels)
     internal_api = None
     model_prop = helm_values.get("model")

--- a/src/apolo_app_types/outputs/update_outputs.py
+++ b/src/apolo_app_types/outputs/update_outputs.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import typing as t
 
 import httpx
@@ -65,42 +66,60 @@ async def update_app_outputs(  # noqa: C901
     app_type = apolo_app_type or helm_outputs["PLATFORM_APPS_APP_TYPE"]
     platform_apps_url = apolo_apps_url or helm_outputs["PLATFORM_APPS_URL"]
     platform_apps_token = apolo_apps_token or helm_outputs["PLATFORM_APPS_TOKEN"]
+    app_instance_id = os.getenv("K8S_INSTANCE_ID", None)
+    if app_instance_id is None:
+        err = "K8S_INSTANCE_ID environment variable is not set."
+        raise ValueError(err)
     try:
         match app_type:
             case AppType.LLMInference:
-                conv_outputs = await get_llm_inference_outputs(helm_outputs)
+                conv_outputs = await get_llm_inference_outputs(
+                    helm_outputs, app_instance_id
+                )
             case AppType.StableDiffusion:
-                conv_outputs = await get_stable_diffusion_outputs(helm_outputs)
+                conv_outputs = await get_stable_diffusion_outputs(
+                    helm_outputs, app_instance_id
+                )
             case AppType.Weaviate:
-                conv_outputs = await get_weaviate_outputs(helm_outputs)
+                conv_outputs = await get_weaviate_outputs(helm_outputs, app_instance_id)
             case AppType.DockerHub:
-                conv_outputs = await get_dockerhub_outputs(helm_outputs)
+                conv_outputs = await get_dockerhub_outputs(
+                    helm_outputs, app_instance_id
+                )
             case AppType.PostgreSQL:
-                conv_outputs = await get_postgres_outputs(helm_outputs)
+                conv_outputs = await get_postgres_outputs(helm_outputs, app_instance_id)
             case AppType.HuggingFaceCache:
-                conv_outputs = await get_huggingface_cache_outputs(helm_outputs)
+                conv_outputs = await get_huggingface_cache_outputs(
+                    helm_outputs, app_instance_id
+                )
             case AppType.CustomDeployment:
-                conv_outputs = await get_custom_deployment_outputs(helm_outputs)
+                conv_outputs = await get_custom_deployment_outputs(
+                    helm_outputs, app_instance_id
+                )
             case AppType.SparkJob:
-                conv_outputs = await get_spark_job_outputs(helm_outputs)
+                conv_outputs = await get_spark_job_outputs(
+                    helm_outputs, app_instance_id
+                )
             case AppType.TextEmbeddingsInference:
-                conv_outputs = await get_tei_outputs(helm_outputs)
+                conv_outputs = await get_tei_outputs(helm_outputs, app_instance_id)
             case AppType.Fooocus:
-                conv_outputs = await get_fooocus_outputs(helm_outputs)
+                conv_outputs = await get_fooocus_outputs(helm_outputs, app_instance_id)
             case AppType.MLFlow:
-                conv_outputs = await get_mlflow_outputs(helm_outputs)
+                conv_outputs = await get_mlflow_outputs(helm_outputs, app_instance_id)
             case AppType.Jupyter:
-                conv_outputs = await get_jupyter_outputs(helm_outputs)
+                conv_outputs = await get_jupyter_outputs(helm_outputs, app_instance_id)
             case AppType.VSCode:
-                conv_outputs = await get_vscode_outputs(helm_outputs)
+                conv_outputs = await get_vscode_outputs(helm_outputs, app_instance_id)
             case AppType.PrivateGPT:
-                conv_outputs = await get_privategpt_outputs(helm_outputs)
+                conv_outputs = await get_privategpt_outputs(
+                    helm_outputs, app_instance_id
+                )
             case AppType.Shell:
-                conv_outputs = await get_shell_outputs(helm_outputs)
+                conv_outputs = await get_shell_outputs(helm_outputs, app_instance_id)
             case AppType.Dify:
-                conv_outputs = await get_dify_outputs(helm_outputs)
+                conv_outputs = await get_dify_outputs(helm_outputs, app_instance_id)
             case AppType.Superset:
-                conv_outputs = await get_superset_outputs(helm_outputs)
+                conv_outputs = await get_superset_outputs(helm_outputs, app_instance_id)
             case _:
                 # Try loading application postprocessor defined in the app repo
                 postprocessor = load_app_postprocessor(

--- a/src/apolo_app_types/outputs/vscode.py
+++ b/src/apolo_app_types/outputs/vscode.py
@@ -2,7 +2,10 @@ import logging
 import typing as t
 
 from apolo_app_types import VSCodeAppOutputs
-from apolo_app_types.outputs.common import get_internal_external_web_urls
+from apolo_app_types.outputs.common import (
+    INSTANCE_LABEL,
+    get_internal_external_web_urls,
+)
 
 
 logger = logging.getLogger()
@@ -12,7 +15,7 @@ async def get_vscode_outputs(
     helm_values: dict[str, t.Any],
     app_instance_id: str,
 ) -> dict[str, t.Any]:
-    labels = {"application": "vscode", "app.kubernetes.io/instance": app_instance_id}
+    labels = {"application": "vscode", INSTANCE_LABEL: app_instance_id}
     internal_web_app_url, external_web_app_url = await get_internal_external_web_urls(
         labels
     )

--- a/src/apolo_app_types/outputs/vscode.py
+++ b/src/apolo_app_types/outputs/vscode.py
@@ -9,10 +9,10 @@ logger = logging.getLogger()
 
 
 async def get_vscode_outputs(
-    helm_values: dict[str, t.Any], labels: dict[str, str] | None = None
+    helm_values: dict[str, t.Any],
+    app_instance_id: str,
 ) -> dict[str, t.Any]:
-    if not labels:
-        labels = {"application": "vscode"}
+    labels = {"application": "vscode", "app.kubernetes.io/instance": app_instance_id}
     internal_web_app_url, external_web_app_url = await get_internal_external_web_urls(
         labels
     )

--- a/src/apolo_app_types/outputs/weaviate.py
+++ b/src/apolo_app_types/outputs/weaviate.py
@@ -6,6 +6,7 @@ from apolo_app_types import (
     WeaviateOutputs,
 )
 from apolo_app_types.clients.kube import get_services
+from apolo_app_types.outputs.common import INSTANCE_LABEL
 from apolo_app_types.outputs.utils.ingress import get_ingress_host_port
 from apolo_app_types.protocols.common.networking import GraphQLAPI, GrpcAPI, RestAPI
 
@@ -19,7 +20,7 @@ async def _get_service_endpoints(
     services = await get_services(
         match_labels={
             "application": release_name,
-            "app.kubernetes.io/instance": app_instance_id,
+            INSTANCE_LABEL: app_instance_id,
         }
     )
     http_host, grpc_host = "", ""
@@ -69,7 +70,7 @@ async def get_weaviate_outputs(
         ingress_host_port = await get_ingress_host_port(
             match_labels={
                 "application": "weaviate",
-                "app.kubernetes.io/instance": app_instance_id,
+                INSTANCE_LABEL: app_instance_id,
             }
         )
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -213,7 +213,10 @@ def mock_kubernetes_client():
         }
 
         def get_services_by_label(namespace, label_selector):
-            if label_selector == "application=weaviate":
+            if (
+                label_selector
+                == "application=weaviate,app.kubernetes.io/instance=test-app-instance-id"  # noqa: E501
+            ):
                 return {
                     "items": [
                         {
@@ -229,7 +232,10 @@ def mock_kubernetes_client():
                         },
                     ]
                 }
-            if label_selector == "application=llm-inference":
+            if (
+                label_selector
+                == "application=llm-inference,app.kubernetes.io/instance=test-app-instance-id"  # noqa: E501
+            ):
                 return {
                     "items": [
                         {
@@ -325,3 +331,9 @@ def mock_kubernetes_client():
             "mock_custom_objects": mock_custom_objects_instance,
             "fake_ingresses": fake_ingresses,
         }
+
+
+@pytest.fixture
+def app_instance_id():
+    """Fixture to provide a mock app instance ID."""
+    return "test-app-instance-id"

--- a/tests/unit/custom_deployment/test_custom_deployment_outputs_generation.py
+++ b/tests/unit/custom_deployment/test_custom_deployment_outputs_generation.py
@@ -5,7 +5,7 @@ from apolo_app_types.outputs.custom_deployment import get_custom_deployment_outp
 
 @pytest.mark.asyncio
 async def test_custom_deployment_outputs_generation_with_ingress(
-    setup_clients, mock_kubernetes_client, monkeypatch
+    setup_clients, mock_kubernetes_client, monkeypatch, app_instance_id: str
 ):
     async def mock_get_service_host_port(*args, **kwargs):
         return ("custom-deployment.default.svc.cluster.local", 80)
@@ -29,7 +29,9 @@ async def test_custom_deployment_outputs_generation_with_ingress(
             "tag": "v1.0.0",
         },
     }
-    res = await get_custom_deployment_outputs(helm_values=helm_values)
+    res = await get_custom_deployment_outputs(
+        helm_values=helm_values, app_instance_id=app_instance_id
+    )
     assert res["external_web_app_url"]["host"] == "custom-deployment.example.com"
     assert res["external_web_app_url"]["port"] == 443
 

--- a/tests/unit/dify/test_dify_outputs_generation.py
+++ b/tests/unit/dify/test_dify_outputs_generation.py
@@ -4,8 +4,8 @@ from apolo_app_types.outputs.dify import get_dify_outputs
 
 
 @pytest.mark.asyncio
-async def test_dify(setup_clients, mock_kubernetes_client):
-    res = await get_dify_outputs({})
+async def test_dify(setup_clients, mock_kubernetes_client, app_instance_id):
+    res = await get_dify_outputs(helm_values={}, app_instance_id=app_instance_id)
 
     assert res["internal_web_app_url"]["host"] == "app.default-namespace"
     assert res["internal_web_app_url"]["port"] == 80
@@ -15,11 +15,14 @@ async def test_dify(setup_clients, mock_kubernetes_client):
 
 
 @pytest.mark.asyncio
-async def test_dify_with_password(setup_clients, mock_kubernetes_client):
+async def test_dify_with_password(
+    setup_clients, mock_kubernetes_client, app_instance_id
+):
     res = await get_dify_outputs(
         {
             "api": {"initPassword": "some_password"},
-        }
+        },
+        app_instance_id=app_instance_id,
     )
 
     assert res["internal_web_app_url"]["host"] == "app.default-namespace"

--- a/tests/unit/dockerhub/test_dockerhub_outputs_generation.py
+++ b/tests/unit/dockerhub/test_dockerhub_outputs_generation.py
@@ -9,7 +9,9 @@ from tests.unit.constants import DEFAULT_NAMESPACE
 
 
 @pytest.mark.asyncio
-async def test_dockerhub_outputs(setup_clients, mock_kubernetes_client):
+async def test_dockerhub_outputs(
+    setup_clients, mock_kubernetes_client, app_instance_id
+):
     res = await get_dockerhub_outputs(
         helm_values={
             "job": {
@@ -25,7 +27,8 @@ async def test_dockerhub_outputs(setup_clients, mock_kubernetes_client):
                     "registry_secret": "test",
                 }
             }
-        }
+        },
+        app_instance_id=app_instance_id,
     )
     auth64 = base64.b64encode(b"test:test")
     dockerconfigjson = base64.b64encode(

--- a/tests/unit/fooocus/test_fooocus_outputs_generation.py
+++ b/tests/unit/fooocus/test_fooocus_outputs_generation.py
@@ -4,8 +4,8 @@ from apolo_app_types.outputs.fooocus import get_fooocus_outputs
 
 
 @pytest.mark.asyncio
-async def test_fooocus_outputs(setup_clients, mock_kubernetes_client):
-    res = await get_fooocus_outputs(helm_values={})
+async def test_fooocus_outputs(setup_clients, mock_kubernetes_client, app_instance_id):
+    res = await get_fooocus_outputs(helm_values={}, app_instance_id=app_instance_id)
 
     assert res["internal_web_app_url"]["host"] == "app.default-namespace"
     assert res["internal_web_app_url"]["port"] == 80

--- a/tests/unit/llm/test_llm_outputs_generation.py
+++ b/tests/unit/llm/test_llm_outputs_generation.py
@@ -4,7 +4,7 @@ from apolo_app_types.outputs.llm import get_llm_inference_outputs
 
 
 @pytest.mark.asyncio
-async def test_llm(setup_clients, mock_kubernetes_client):
+async def test_llm(setup_clients, mock_kubernetes_client, app_instance_id):
     res = await get_llm_inference_outputs(
         helm_values={
             "model": {
@@ -13,7 +13,8 @@ async def test_llm(setup_clients, mock_kubernetes_client):
             },
             "serverExtraArgs": ["--api-key dummy-api-key"],
             "env": {"VLLM_API_KEY": "dummy"},
-        }
+        },
+        app_instance_id=app_instance_id,
     )
     assert res["hugging_face_model"] == {
         "model_hf_name": "meta-llama/Llama-3.1-8B-Instruct",
@@ -31,7 +32,9 @@ async def test_llm(setup_clients, mock_kubernetes_client):
 
 
 @pytest.mark.asyncio
-async def test_llm_without_server_args(setup_clients, mock_kubernetes_client):
+async def test_llm_without_server_args(
+    setup_clients, mock_kubernetes_client, app_instance_id
+):
     res = await get_llm_inference_outputs(
         helm_values={
             "model": {
@@ -39,7 +42,8 @@ async def test_llm_without_server_args(setup_clients, mock_kubernetes_client):
                 "tokenizerHFName": "meta-llama/Llama-3.1-8B-Instruct",
             },
             "env": {"VLLM_API_KEY": "dummy-api-key"},
-        }
+        },
+        app_instance_id=app_instance_id,
     )
 
     assert res["hugging_face_model"] == {
@@ -58,7 +62,12 @@ async def test_llm_without_server_args(setup_clients, mock_kubernetes_client):
 
 
 @pytest.mark.asyncio
-async def test_llm_without_model(setup_clients, mock_kubernetes_client):
+async def test_llm_without_model(
+    setup_clients, mock_kubernetes_client, app_instance_id
+):
     with pytest.raises(KeyError) as exc_info:
-        await get_llm_inference_outputs(helm_values={"env": {"VLLM_API_KEY": "dummy"}})
+        await get_llm_inference_outputs(
+            helm_values={"env": {"VLLM_API_KEY": "dummy"}},
+            app_instance_id=app_instance_id,
+        )
     assert str(exc_info.value) == "'model'"

--- a/tests/unit/mlflow/test_mlflow_outputs_generation.py
+++ b/tests/unit/mlflow/test_mlflow_outputs_generation.py
@@ -5,7 +5,7 @@ from apolo_app_types.outputs.mlflow import get_mlflow_outputs
 
 @pytest.mark.asyncio
 async def test_mlflow_outputs_generation(
-    setup_clients, mock_kubernetes_client, monkeypatch
+    setup_clients, mock_kubernetes_client, monkeypatch, app_instance_id
 ):
     """
     Validate that get_mlflow_outputs returns the correct
@@ -40,7 +40,7 @@ async def test_mlflow_outputs_generation(
 
     helm_values = {"labels": {"application": "mlflow"}}
 
-    result = await get_mlflow_outputs(helm_values)
+    result = await get_mlflow_outputs(helm_values, app_instance_id=app_instance_id)
     assert result["web_app_url"]["internal_url"] is not None
     assert (
         result["web_app_url"]["internal_url"]["host"]

--- a/tests/unit/postgres/test_postgres_outputs_generator.py
+++ b/tests/unit/postgres/test_postgres_outputs_generator.py
@@ -1,8 +1,8 @@
 from apolo_app_types.outputs.postgres import get_postgres_outputs
 
 
-async def test_postgres_outputs(setup_clients, mock_kubernetes_client):
-    res = await get_postgres_outputs(helm_values={})
+async def test_postgres_outputs(setup_clients, mock_kubernetes_client, app_instance_id):
+    res = await get_postgres_outputs(helm_values={}, app_instance_id=app_instance_id)
     assert res["postgres_users"]["users"] == [
         {
             "dbname": "mydatabase",

--- a/tests/unit/shell/test_shell_outputs_generation.py
+++ b/tests/unit/shell/test_shell_outputs_generation.py
@@ -4,8 +4,8 @@ from apolo_app_types.outputs.shell import get_shell_outputs
 
 
 @pytest.mark.asyncio
-async def test_shell_outputs(setup_clients, mock_kubernetes_client):
-    res = await get_shell_outputs(helm_values={})
+async def test_shell_outputs(setup_clients, mock_kubernetes_client, app_instance_id):
+    res = await get_shell_outputs(helm_values={}, app_instance_id=app_instance_id)
 
     assert res["internal_web_app_url"]["host"] == "app.default-namespace"
     assert res["internal_web_app_url"]["port"] == 80

--- a/tests/unit/spark/test_spark_job_outputs_generation.py
+++ b/tests/unit/spark/test_spark_job_outputs_generation.py
@@ -4,12 +4,16 @@ from apolo_app_types.outputs.spark_job import get_spark_job_outputs
 
 
 @pytest.mark.asyncio
-async def test_spark_job_outputs(setup_clients, mock_kubernetes_client, monkeypatch):
+async def test_spark_job_outputs(
+    setup_clients, mock_kubernetes_client, monkeypatch, app_instance_id
+):
     helm_values = {
         "image": {
             "repository": "myrepo/custom-deployment",
             "tag": "v1.0.0",
         },
     }
-    res = await get_spark_job_outputs(helm_values=helm_values)
+    res = await get_spark_job_outputs(
+        helm_values=helm_values, app_instance_id=app_instance_id
+    )
     assert res == {}

--- a/tests/unit/stable_diffusion/test_sd_outputs_generation.py
+++ b/tests/unit/stable_diffusion/test_sd_outputs_generation.py
@@ -4,12 +4,13 @@ from apolo_app_types.outputs.stable_diffusion import get_stable_diffusion_output
 
 
 @pytest.mark.asyncio
-async def test_sd(setup_clients, mock_kubernetes_client):
+async def test_sd(setup_clients, mock_kubernetes_client, app_instance_id):
     res = await get_stable_diffusion_outputs(
         helm_values={
             "model": {"modelHFName": "SD-Model"},
             "env": {"VLLM_API_KEY": "dummy-api-key"},
-        }
+        },
+        app_instance_id=app_instance_id,
     )
 
     assert res
@@ -24,13 +25,14 @@ async def test_sd(setup_clients, mock_kubernetes_client):
 
 
 @pytest.mark.asyncio
-async def test_sd_without_files(setup_clients, mock_kubernetes_client):
+async def test_sd_without_files(setup_clients, mock_kubernetes_client, app_instance_id):
     res = await get_stable_diffusion_outputs(
         helm_values={
             "model": {
                 "modelHFName": "SD-Model",
             }
-        }
+        },
+        app_instance_id=app_instance_id,
     )
 
     assert res
@@ -45,8 +47,10 @@ async def test_sd_without_files(setup_clients, mock_kubernetes_client):
 
 
 @pytest.mark.asyncio
-async def test_sd_without_model(setup_clients, mock_kubernetes_client):
+async def test_sd_without_model(setup_clients, mock_kubernetes_client, app_instance_id):
     with pytest.raises(KeyError) as exc_info:
-        await get_stable_diffusion_outputs(helm_values={})
+        await get_stable_diffusion_outputs(
+            helm_values={}, app_instance_id=app_instance_id
+        )
 
     assert str(exc_info.value) == "'model'"

--- a/tests/unit/text_embeddings/test_tei_outputs_generation.py
+++ b/tests/unit/text_embeddings/test_tei_outputs_generation.py
@@ -4,8 +4,8 @@ from apolo_app_types.outputs.tei import get_tei_outputs
 
 
 @pytest.mark.asyncio
-async def test_tei_outputs(setup_clients, mock_kubernetes_client):
-    res = await get_tei_outputs(helm_values={})
+async def test_tei_outputs(setup_clients, mock_kubernetes_client, app_instance_id):
+    res = await get_tei_outputs(helm_values={}, app_instance_id=app_instance_id)
 
     assert res["internal_api"]["host"] == "app.default-namespace"
     assert res["internal_api"]["port"] == 80
@@ -17,13 +17,16 @@ async def test_tei_outputs(setup_clients, mock_kubernetes_client):
 
 
 @pytest.mark.asyncio
-async def test_tei_outputs_with_model(setup_clients, mock_kubernetes_client):
+async def test_tei_outputs_with_model(
+    setup_clients, mock_kubernetes_client, app_instance_id
+):
     res = await get_tei_outputs(
         helm_values={
             "model": {
                 "modelHFName": "random/name",
             },
-        }
+        },
+        app_instance_id=app_instance_id,
     )
 
     assert res["internal_api"]["host"] == "app.default-namespace"

--- a/tests/unit/weaviate/test_weaviate_outputs_generation.py
+++ b/tests/unit/weaviate/test_weaviate_outputs_generation.py
@@ -4,7 +4,9 @@ from apolo_app_types.outputs.weaviate import get_weaviate_outputs
 
 
 @pytest.mark.asyncio
-async def test_output_values_weaviate(setup_clients, mock_kubernetes_client):
+async def test_output_values_weaviate(
+    setup_clients, mock_kubernetes_client, app_instance_id
+):
     res = await get_weaviate_outputs(
         {
             "nameOverride": "weaviate",
@@ -13,7 +15,8 @@ async def test_output_values_weaviate(setup_clients, mock_kubernetes_client):
                 "password": "admin",
             },
             "ingress": {"enabled": True},
-        }
+        },
+        app_instance_id=app_instance_id,
     )
     assert res["auth"] == {
         "username": "admin",
@@ -32,12 +35,13 @@ async def test_output_values_weaviate(setup_clients, mock_kubernetes_client):
 
 @pytest.mark.asyncio
 async def test_output_values_weaviate_without_cluster_creds(
-    setup_clients, mock_kubernetes_client
+    setup_clients, mock_kubernetes_client, app_instance_id
 ):
     res = await get_weaviate_outputs(
         {
             "ingress": {"enabled": True},
-        }
+        },
+        app_instance_id=app_instance_id,
     )
     assert res["auth"] == {
         "username": "",


### PR DESCRIPTION
This pull request introduces a significant refactor to the handling of Kubernetes instance identifiers (`app.kubernetes.io/instance`) across various application output functions. The changes ensure that the `app_instance_id` is consistently passed as a parameter and incorporated into label matching for Kubernetes resources. Additionally, it includes updates to environment variable handling and unit tests to support these changes.

### Kubernetes Instance Identifier Integration

* **Addition of `app_instance_id` parameter**: Updated all application output functions (e.g., `get_llm_inference_outputs`, `get_stable_diffusion_outputs`, etc.) to include an `app_instance_id` parameter and incorporate it into label matching for Kubernetes resources. This ensures that resource queries are scoped to the correct application instance. [[1]](diffhunk://#diff-e8705afa936ea9117dbb7c82045d208747ba0a30efab2373bddd23b3efae0c50L12-R20) [[2]](diffhunk://#diff-e32e25f0b9e37fa593c5163fb0b160c295ae5480f9972f364c843e7ea04b7889R11-R14) [[3]](diffhunk://#diff-165f6e06807292eb681610349895e9a395d81b8dd2d2565cd53f68e8a918e892L12-R14) [[4]](diffhunk://#diff-d7dad841f4a7d2a216f752c1d2ccecef7638f968b890bf5b85a6f3a8dac8f764L14-R16) [[5]](diffhunk://#diff-fa9d3374b25d20be8bbac71e4b025e8c5e0ea99e065e8b1f3ae2ff0db7fcba77L12-R14) [[6]](diffhunk://#diff-8dfe28648ac768495f51d79760716b497ae3ebeced2ea567d6229af25a240ef1L20-R27) [[7]](diffhunk://#diff-6aace827303f63986f0ce631f8fcfa1db546125044efc4de1342bd585c5d5900R12-R14) [[8]](diffhunk://#diff-0b5d8986def043928b25d581315214e3add2ce18e30eed400b4af1c9a67884f9R74) [[9]](diffhunk://#diff-089bf0d5f43917cf68cd25621fe9af6e3c2ab0be950d21e4db9954a73a20631bR11-R16) [[10]](diffhunk://#diff-b47efcfb65760b2ff96c2ba6559abedd669f9cf1e192daa4b7850f233ccf04a3R9-R11) [[11]](diffhunk://#diff-4098f6ec6383a7a77b1a263509acbbfd8ac666d94f61e071e75bcefc08651c7aR10) [[12]](diffhunk://#diff-58571bf6e3082d10e97dc83e6f8fc88fd0bb6bc4475d02270dba58f518e49c93R16-R25) [[13]](diffhunk://#diff-f97aac0ba30faf0b32c8a541467f6c6a48cee7c982a238de03547c2fa8fea0d6R12-R14) [[14]](diffhunk://#diff-19b35e065cd3849f854a5eb9f7756fb26ea0f95232ed160e1ecc499ef0f41ca0R12-R17) [[15]](diffhunk://#diff-4933337b60ccbcfc37dc58ec52d4a9d6200041849cb9bf4f33a1970e90d46401L17-R24) [[16]](diffhunk://#diff-4933337b60ccbcfc37dc58ec52d4a9d6200041849cb9bf4f33a1970e90d46401L39-R52) [[17]](diffhunk://#diff-4933337b60ccbcfc37dc58ec52d4a9d6200041849cb9bf4f33a1970e90d46401L63-R73) [[18]](diffhunk://#diff-43ef1965603296f9543cf0d1742288984303cb3c139f5e44a5ad4da0d46ac68bL12-R15)

* **Environment variable handling**: Added logic in `update_app_outputs` to retrieve the `app_instance_id` from the environment variable `K8S_INSTANCE_ID`. If the variable is not set, an error is raised to ensure proper configuration.

### Label Matching Enhancements

* **Consistent label updates**: Modified label matching logic in various functions to include the `app_instance_id` in Kubernetes resource queries. This applies to services, ingresses, and other resources. [[1]](diffhunk://#diff-e32e25f0b9e37fa593c5163fb0b160c295ae5480f9972f364c843e7ea04b7889L24-R26) [[2]](diffhunk://#diff-e32e25f0b9e37fa593c5163fb0b160c295ae5480f9972f364c843e7ea04b7889L36-R38) [[3]](diffhunk://#diff-4933337b60ccbcfc37dc58ec52d4a9d6200041849cb9bf4f33a1970e90d46401L63-R73)

### Unit Test Updates

* **Mock updates**: Updated unit test mocks to account for the inclusion of `app_instance_id` in label matching. This ensures tests accurately reflect the new behavior. [[1]](diffhunk://#diff-0cae8a7ee2d37098b1ad84b543d17cfc1e8535eed5fd6abac88c668bfe354cbbL216-R219) [[2]](diffhunk://#diff-0cae8a7ee2d37098b1ad84b543d17cfc1e8535eed5fd6abac88c668bfe354cbbL232-R238)
* **New fixture**: Added a fixture to provide a mock `app_instance_id` for unit tests.

### Miscellaneous Changes

* **Environment variable import**: Added `os` import in `update_outputs.py` to support environment variable handling.
* **Post-install hook update**: Added `K8S_INSTANCE_ID` to environment variables in the Helm chart post-install hook template.