### PR TITLE
Add support for ConfigMap in CustomDeployment inputs and values generation

### DIFF
--- a/src/apolo_app_types/helm/apps/custom_deployment.py
+++ b/src/apolo_app_types/helm/apps/custom_deployment.py
@@ -138,20 +138,21 @@ class CustomDeploymentChartValueProcessor(
         health_checks = get_custom_deployment_health_check_values(input_.health_checks)
         values |= health_checks
 
+        configmap_name = "app-configmap"
         if input_.config_map:
             values["configMap"] = {
                 "enabled": True,
-                "name": input_.config_map.name,
+                "name": configmap_name,
                 "data": {item.key: item.value for item in input_.config_map.data},
             }
             volume = {
-                "name": input_.config_map.name,
+                "name": configmap_name,
                 "configMap": {
-                    "name": input_.config_map.name,
+                    "name": configmap_name,
                 },
             }
             volume_mount = {
-                "name": input_.config_map.name,
+                "name": configmap_name,
                 "mountPath": input_.config_map.mount_path.path,
             }
             values.setdefault("volumes", []).append(volume)

--- a/src/apolo_app_types/protocols/custom_deployment.py
+++ b/src/apolo_app_types/protocols/custom_deployment.py
@@ -62,22 +62,24 @@ class ConfigMapKeyValue(BaseModel):
     model_config = ConfigDict(
         protected_namespaces=(),
         json_schema_extra=SchemaExtraMetadata(
-            title="ConfigMap Key-Value Pair",
-            description="Define a key-value pair for the ConfigMap.",
+            title="Key-Value Pair",
+            description="Define a key-value pair."
+            " Each key will be a file in the mounted directory.",
         ).as_json_schema_extra(),
     )
     key: str = Field(
         ...,
         json_schema_extra=SchemaExtraMetadata(
             title="Key",
-            description="The key for the ConfigMap entry.",
+            description="The key for the entry. "
+            "It will be used as a file name in the mounted directory.",
         ).as_json_schema_extra(),
     )
     value: str = Field(
         ...,
         json_schema_extra=SchemaExtraMetadata(
             title="Value",
-            description="The value associated with the ConfigMap key.",
+            description="The value associated with the key.",
         ).as_json_schema_extra(),
     )
 
@@ -86,24 +88,18 @@ class ConfigMap(AbstractAppFieldType):
     model_config = ConfigDict(
         protected_namespaces=(),
         json_schema_extra=SchemaExtraMetadata(
-            title="ConfigMap",
-            description="Use ConfigMap to store non-sensitive"
-            " configuration data that can be mounted into the"
-            " application as environment variables or files.",
-        ).as_json_schema_extra(),
-    )
-
-    name: str = Field(
-        json_schema_extra=SchemaExtraMetadata(
-            description="The name of the ConfigMap to use.",
-            title="ConfigMap Name",
+            title="Mount Configuration Data",
+            description="Store non-sensitive"
+            " configuration data in key-value format"
+            " that can be mounted into the"
+            " application as files.",
         ).as_json_schema_extra(),
     )
     mount_path: MountPath = Field(
         json_schema_extra=SchemaExtraMetadata(
             title="Mount Path",
-            description="The path where the ConfigMap will be"
-            " mounted in the container.",
+            description="The path where the key-value pairs"
+            " will be mounted in the container.",
         ).as_json_schema_extra(),
     )
     data: list[ConfigMapKeyValue]

--- a/tests/unit/custom_deployment/test_custom_deployment_input_generation.py
+++ b/tests/unit/custom_deployment/test_custom_deployment_input_generation.py
@@ -459,7 +459,6 @@ async def test_custom_deployment_values_configmap_checks(
                 ingress_http=IngressHttp(),
             ),
             config_map=ConfigMap(
-                name="configmap-name",
                 mount_path=MountPath(path="/config"),
                 data=[
                     ConfigMapKeyValue(key="config_key", value="config_value"),
@@ -492,16 +491,16 @@ async def test_custom_deployment_values_configmap_checks(
     assert "configMap" in helm_params
     assert helm_params["configMap"] == {
         "enabled": True,
-        "name": "configmap-name",
+        "name": "app-configmap",
         "data": {"config_key": "config_value", "config_key_2": "config_value_2"},
     }
     assert {
-        "name": "configmap-name",
+        "name": "app-configmap",
         "configMap": {
-            "name": "configmap-name",
+            "name": "app-configmap",
         },
     } in helm_params["volumes"]
     assert {
-        "name": "configmap-name",
+        "name": "app-configmap",
         "mountPath": "/config",
     } in helm_params["volumeMounts"]


### PR DESCRIPTION
Added ConfigMap option to Service Deployment app. 

I'm not calling it ConfigMap directly in the description. Wdyt?

Resulting UI:


https://github.com/user-attachments/assets/b0ef7b44-45d7-465f-8050-23c2a13cef25


