### PR TITLE
Support for apolo_app_id Helm Value

### DIFF
--- a/src/apolo_app_types/helm/apps/base.py
+++ b/src/apolo_app_types/helm/apps/base.py
@@ -26,6 +26,7 @@ class BaseChartValueProcessor(abc.ABC, t.Generic[AppInputT]):
         app_name: str,
         namespace: str,
         app_secrets_name: str,
+        app_id: str | None = None,
         *args: t.Any,
         **kwargs: t.Any,
     ) -> dict[str, t.Any]:

--- a/src/apolo_app_types/helm/apps/common.py
+++ b/src/apolo_app_types/helm/apps/common.py
@@ -261,6 +261,7 @@ async def gen_extra_values(
     namespace: str | None = None,
     port_configurations: list[Port] | None = None,
     component_name: str | None = None,
+    app_id: str | None = None,
 ) -> dict[str, t.Any]:
     preset_name = preset_type.name
     if not preset_name:
@@ -300,6 +301,10 @@ async def gen_extra_values(
         if "annotations" not in ingress_vals["ingress"] and grpc_ingress_conf:
             ingress_vals["ingress"]["annotations"] = {}
 
+    app_specific = {}
+    if app_id:
+        app_specific["apolo_app_id"] = app_id
+
     return {
         "preset_name": preset_name,
         "resources": resources_vals,
@@ -310,4 +315,8 @@ async def gen_extra_values(
             "platform.apolo.us/preset": preset_name,
         },
         **ingress_vals,
+        **app_specific,
     }
+
+
+# async def gen_

--- a/src/apolo_app_types/helm/apps/custom_deployment.py
+++ b/src/apolo_app_types/helm/apps/custom_deployment.py
@@ -138,20 +138,21 @@ class CustomDeploymentChartValueProcessor(
         health_checks = get_custom_deployment_health_check_values(input_.health_checks)
         values |= health_checks
 
+        configmap_name = "app-configmap"
         if input_.config_map:
             values["configMap"] = {
                 "enabled": True,
-                "name": input_.config_map.name,
+                "name": configmap_name,
                 "data": {item.key: item.value for item in input_.config_map.data},
             }
             volume = {
-                "name": input_.config_map.name,
+                "name": configmap_name,
                 "configMap": {
-                    "name": input_.config_map.name,
+                    "name": configmap_name,
                 },
             }
             volume_mount = {
-                "name": input_.config_map.name,
+                "name": configmap_name,
                 "mountPath": input_.config_map.mount_path.path,
             }
             values.setdefault("volumes", []).append(volume)

--- a/src/apolo_app_types/helm/apps/custom_deployment.py
+++ b/src/apolo_app_types/helm/apps/custom_deployment.py
@@ -52,6 +52,7 @@ class CustomDeploymentChartValueProcessor(
         app_name: str,
         namespace: str,
         app_secrets_name: str,
+        app_id: str | None = None,
         *_: t.Any,
         **kwargs: t.Any,
     ) -> dict[str, t.Any]:
@@ -67,6 +68,7 @@ class CustomDeploymentChartValueProcessor(
             ingress_http=input_.networking.ingress_http,
             ingress_grpc=None,
             port_configurations=input_.networking.ports,
+            app_id=app_id,
         )
         image_docker_url = await get_image_docker_url(
             client=self.client,
@@ -78,6 +80,7 @@ class CustomDeploymentChartValueProcessor(
             "image": {
                 "repository": image,
                 "tag": tag,
+                "pullPolicy": input_.image.pull_policy.value,
             },
             **extra_values,
         }

--- a/src/apolo_app_types/helm/apps/custom_deployment.py
+++ b/src/apolo_app_types/helm/apps/custom_deployment.py
@@ -138,4 +138,23 @@ class CustomDeploymentChartValueProcessor(
         health_checks = get_custom_deployment_health_check_values(input_.health_checks)
         values |= health_checks
 
+        if input_.config_map:
+            values["configMap"] = {
+                "enabled": True,
+                "name": input_.config_map.name,
+                "data": {item.key: item.value for item in input_.config_map.data},
+            }
+            volume = {
+                "name": input_.config_map.name,
+                "configMap": {
+                    "name": input_.config_map.name,
+                },
+            }
+            volume_mount = {
+                "name": input_.config_map.name,
+                "mountPath": input_.config_map.mount_path.path,
+            }
+            values.setdefault("volumes", []).append(volume)
+            values.setdefault("volumeMounts", []).append(volume_mount)
+
         return values

--- a/src/apolo_app_types/inputs/args.py
+++ b/src/apolo_app_types/inputs/args.py
@@ -50,6 +50,7 @@ async def app_type_to_vals(
     app_name: str,
     namespace: str,
     app_secrets_name: str,
+    app_id: str | None = None,
 ) -> tuple[list[str], dict[str, t.Any]]:
     # Mapping AppType to their respective processor classes
     processor_map: dict[AppType, type[BaseChartValueProcessor[t.Any]]] = {
@@ -84,6 +85,7 @@ async def app_type_to_vals(
         app_name=app_name,
         namespace=namespace,
         app_secrets_name=app_secrets_name,
+        app_id=app_id,
     )
     return extra_helm_args, extra_vals
 
@@ -95,6 +97,7 @@ async def get_installation_vals(
     app_type: AppType,
     namespace: str = "default",
     app_secrets_name: str = "apps-secrets",
+    app_id: str | None = None,
 ) -> dict[str, t.Any]:
     input_type_map: dict[AppType, type[AppInputs]] = {
         AppType.LLMInference: LLMInputs,
@@ -127,6 +130,7 @@ async def get_installation_vals(
         app_name,
         namespace=namespace,
         app_secrets_name=app_secrets_name,
+        app_id=app_id,
     )
 
     return extra_vals

--- a/src/apolo_app_types/protocols/common/containers.py
+++ b/src/apolo_app_types/protocols/common/containers.py
@@ -1,3 +1,5 @@
+from enum import StrEnum
+
 from pydantic import ConfigDict, Field
 
 from apolo_app_types.protocols.common.abc_ import AbstractAppFieldType
@@ -6,6 +8,12 @@ from apolo_app_types.protocols.common.schema_extra import (
     SchemaMetaType,
 )
 from apolo_app_types.protocols.dockerhub import DockerConfigModel
+
+
+class ContainerImagePullPolicy(StrEnum):
+    ALWAYS = "Always"
+    NEVER = "Never"
+    IF_NOT_PRESENT = "IfNotPresent"
 
 
 class ContainerImage(AbstractAppFieldType):
@@ -36,5 +44,12 @@ class ContainerImage(AbstractAppFieldType):
             title="ImagePullSecrets for DockerHub",
             description="ImagePullSecrets for DockerHub",
             meta_type=SchemaMetaType.INTEGRATION,
+        ).as_json_schema_extra(),
+    )
+    pull_policy: ContainerImagePullPolicy = Field(
+        default=ContainerImagePullPolicy.IF_NOT_PRESENT,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Container Image Pull Policy",
+            description="Specify the pull policy for the container image.",
         ).as_json_schema_extra(),
     )

--- a/src/apolo_app_types/protocols/custom_deployment.py
+++ b/src/apolo_app_types/protocols/custom_deployment.py
@@ -62,22 +62,24 @@ class ConfigMapKeyValue(BaseModel):
     model_config = ConfigDict(
         protected_namespaces=(),
         json_schema_extra=SchemaExtraMetadata(
-            title="ConfigMap Key-Value Pair",
-            description="Define a key-value pair for the ConfigMap.",
+            title="Key-Value Pair",
+            description="Define a key-value pair."
+            " Each key will be a file in the mounted directory.",
         ).as_json_schema_extra(),
     )
     key: str = Field(
         ...,
         json_schema_extra=SchemaExtraMetadata(
             title="Key",
-            description="The key for the ConfigMap entry.",
+            description="The key for the entry. "
+            "It will be used as a file name in the mounted directory.",
         ).as_json_schema_extra(),
     )
     value: str = Field(
         ...,
         json_schema_extra=SchemaExtraMetadata(
             title="Value",
-            description="The value associated with the ConfigMap key.",
+            description="The value associated with the key.",
         ).as_json_schema_extra(),
     )
 
@@ -86,24 +88,18 @@ class ConfigMap(AbstractAppFieldType):
     model_config = ConfigDict(
         protected_namespaces=(),
         json_schema_extra=SchemaExtraMetadata(
-            title="ConfigMap",
-            description="Use ConfigMap to store non-sensitive"
-            " configuration data that can be mounted into the"
-            " application as environment variables or files.",
-        ).as_json_schema_extra(),
-    )
-
-    name: str = Field(
-        json_schema_extra=SchemaExtraMetadata(
-            description="The name of the ConfigMap to use.",
-            title="ConfigMap Name",
+            title="Mount Configuration Data",
+            description="Store non-sensitive"
+            " configuration data in key-value format"
+            " that can be mounted into the"
+            " application as files.",
         ).as_json_schema_extra(),
     )
     mount_path: MountPath = Field(
         json_schema_extra=SchemaExtraMetadata(
             title="Mount Path",
-            description="The path where the ConfigMap will be"
-            " mounted in the container.",
+            description="The path where the key-value pairs"
+            " will be mounted in the container.",
         ).as_json_schema_extra(),
     )
     data: list[ConfigMapKeyValue]

--- a/src/apolo_app_types/protocols/custom_deployment.py
+++ b/src/apolo_app_types/protocols/custom_deployment.py
@@ -12,10 +12,12 @@ from apolo_app_types.protocols.common import (
     SchemaExtraMetadata,
     StorageMounts,
 )
+from apolo_app_types.protocols.common.abc_ import AbstractAppFieldType
 from apolo_app_types.protocols.common.health_check import (
     HealthCheckProbesConfig,
 )
 from apolo_app_types.protocols.common.k8s import Port
+from apolo_app_types.protocols.common.storage import MountPath
 
 
 class NetworkingConfig(BaseModel):
@@ -56,6 +58,57 @@ class NetworkingConfig(BaseModel):
     )
 
 
+class ConfigMapKeyValue(BaseModel):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="ConfigMap Key-Value Pair",
+            description="Define a key-value pair for the ConfigMap.",
+        ).as_json_schema_extra(),
+    )
+    key: str = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Key",
+            description="The key for the ConfigMap entry.",
+        ).as_json_schema_extra(),
+    )
+    value: str = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Value",
+            description="The value associated with the ConfigMap key.",
+        ).as_json_schema_extra(),
+    )
+
+
+class ConfigMap(AbstractAppFieldType):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="ConfigMap",
+            description="Use ConfigMap to store non-sensitive"
+            " configuration data that can be mounted into the"
+            " application as environment variables or files.",
+        ).as_json_schema_extra(),
+    )
+
+    name: str = Field(
+        json_schema_extra=SchemaExtraMetadata(
+            description="The name of the ConfigMap to use.",
+            title="ConfigMap Name",
+        ).as_json_schema_extra(),
+    )
+    mount_path: MountPath = Field(
+        json_schema_extra=SchemaExtraMetadata(
+            title="Mount Path",
+            description="The path where the ConfigMap will be"
+            " mounted in the container.",
+        ).as_json_schema_extra(),
+    )
+    data: list[ConfigMapKeyValue]
+
+
 class CustomDeploymentInputs(AppInputs):
     model_config = ConfigDict(
         protected_namespaces=(),
@@ -82,6 +135,7 @@ class CustomDeploymentInputs(AppInputs):
             is_advanced_field=True,
         ).as_json_schema_extra(),
     )
+    config_map: ConfigMap | None = Field(default=None)
     storage_mounts: StorageMounts | None = Field(
         default=None,
         json_schema_extra=SchemaExtraMetadata(

--- a/tests/unit/custom_deployment/test_custom_deployment_input_generation.py
+++ b/tests/unit/custom_deployment/test_custom_deployment_input_generation.py
@@ -459,7 +459,6 @@ async def test_custom_deployment_values_configmap_checks(
                 ingress_http=IngressHttp(),
             ),
             config_map=ConfigMap(
-                name="configmap-name",
                 mount_path=MountPath(path="/config"),
                 data=[
                     ConfigMapKeyValue(key="config_key", value="config_value"),
@@ -492,16 +491,16 @@ async def test_custom_deployment_values_configmap_checks(
     assert "configMap" in helm_params
     assert helm_params["configMap"] == {
         "enabled": True,
-        "name": "configmap-name",
+        "name": "app-configmap",
         "data": {"config_key": "config_value", "config_key_2": "config_value_2"},
     }
     assert {
-        "name": "configmap-name",
+        "name": "app-configmap",
         "configMap": {
-            "name": "configmap-name",
+            "name": "app-configmap",
         },
     } in helm_params["volumes"]
     assert {
-        "name": "configmap-name",
+        "name": "app-configmap",
         "mountPath": "/config",
     } in helm_params["volumeMounts"]

--- a/tests/unit/custom_deployment/test_custom_deployment_input_generation.py
+++ b/tests/unit/custom_deployment/test_custom_deployment_input_generation.py
@@ -25,6 +25,8 @@ from apolo_app_types.protocols.common.storage import (
     MountPath,
 )
 from apolo_app_types.protocols.custom_deployment import (
+    ConfigMap,
+    ConfigMapKeyValue,
     CustomDeploymentInputs,
     NetworkingConfig,
     StorageMounts,
@@ -427,3 +429,79 @@ async def test_custom_deployment_values_generation_with_health_checks(
         "initialDelaySeconds": 5,
         "periodSeconds": 10,
     }
+
+
+@pytest.mark.asyncio
+async def test_custom_deployment_values_configmap_checks(
+    setup_clients,
+):
+    """
+    Ensure that when health checks are provided, they are properly
+    configured in the helm values
+    """
+    helm_args, helm_params = await app_type_to_vals(
+        input_=CustomDeploymentInputs(
+            preset=Preset(name="cpu-small"),
+            image=ContainerImage(
+                repository="myrepo/custom-deployment",
+                tag="v1.2.3",
+            ),
+            container=Container(
+                command=["python", "app.py"],
+                args=["--port", "8080"],
+                env=[Env(name="ENV_VAR", value="value")],
+            ),
+            networking=NetworkingConfig(
+                service_enabled=True,
+                ports=[
+                    Port(name="http", port=8080),
+                ],
+                ingress_http=IngressHttp(),
+            ),
+            config_map=ConfigMap(
+                name="configmap-name",
+                mount_path=MountPath(path="/config"),
+                data=[
+                    ConfigMapKeyValue(key="config_key", value="config_value"),
+                    ConfigMapKeyValue(key="config_key_2", value="config_value_2"),
+                ],
+            ),
+        ),
+        apolo_client=setup_clients,
+        app_type=AppType.CustomDeployment,
+        app_name="custom-app",
+        namespace="default-namespace",
+        app_secrets_name=APP_SECRETS_NAME,
+    )
+
+    # Base assertions
+    assert helm_params["image"] == {
+        "repository": "myrepo/custom-deployment",
+        "tag": "v1.2.3",
+    }
+    assert helm_params["container"] == {
+        "command": ["python", "app.py"],
+        "args": ["--port", "8080"],
+        "env": [{"name": "ENV_VAR", "value": "value"}],
+    }
+    assert helm_params["service"] == {
+        "enabled": True,
+        "ports": [{"name": "http", "containerPort": 8080}],
+    }
+
+    assert "configMap" in helm_params
+    assert helm_params["configMap"] == {
+        "enabled": True,
+        "name": "configmap-name",
+        "data": {"config_key": "config_value", "config_key_2": "config_value_2"},
+    }
+    assert {
+        "name": "configmap-name",
+        "configMap": {
+            "name": "configmap-name",
+        },
+    } in helm_params["volumes"]
+    assert {
+        "name": "configmap-name",
+        "mountPath": "/config",
+    } in helm_params["volumeMounts"]

--- a/tests/unit/custom_deployment/test_custom_deployment_input_generation.py
+++ b/tests/unit/custom_deployment/test_custom_deployment_input_generation.py
@@ -63,6 +63,7 @@ async def test_custom_deployment_values_generation(setup_clients):
     assert helm_params["image"] == {
         "repository": "myrepo/custom-deployment",
         "tag": "v1.2.3",
+        "pullPolicy": "IfNotPresent",
     }
     assert helm_params["container"] == {
         "command": ["python", "app.py"],
@@ -133,6 +134,7 @@ async def test_custom_deployment_values_generation_with_storage_mounts(setup_cli
     assert helm_params["image"] == {
         "repository": "myrepo/custom-deployment",
         "tag": "v1.2.3",
+        "pullPolicy": "IfNotPresent",
     }
     assert helm_params["container"] == {
         "command": ["python", "app.py"],
@@ -204,6 +206,7 @@ async def test_custom_deployment_values_generation_with_multiport_exposure(
     assert helm_params["image"] == {
         "repository": "multiport",
         "tag": "latest",
+        "pullPolicy": "IfNotPresent",
     }
     assert helm_params["container"] == {
         "command": ["python", "app.py"],
@@ -262,6 +265,7 @@ async def test_custom_deployment_values_generation_path_port_not_supplied(
     assert helm_params["image"] == {
         "repository": "any",
         "tag": "latest",
+        "pullPolicy": "IfNotPresent",
     }
     assert helm_params["container"] == {
         "command": ["python", "app.py"],
@@ -311,6 +315,7 @@ async def test_custom_deployment_values_generation_network_not_supplied(
     assert helm_params["image"] == {
         "repository": "any",
         "tag": "latest",
+        "pullPolicy": "IfNotPresent",
     }
     assert helm_params["container"] == {
         "command": ["python", "app.py"],
@@ -392,6 +397,7 @@ async def test_custom_deployment_values_generation_with_health_checks(
     assert helm_params["image"] == {
         "repository": "myrepo/custom-deployment",
         "tag": "v1.2.3",
+        "pullPolicy": "IfNotPresent",
     }
     assert helm_params["container"] == {
         "command": ["python", "app.py"],
@@ -477,6 +483,7 @@ async def test_custom_deployment_values_configmap_checks(
     assert helm_params["image"] == {
         "repository": "myrepo/custom-deployment",
         "tag": "v1.2.3",
+        "pullPolicy": "IfNotPresent",
     }
     assert helm_params["container"] == {
         "command": ["python", "app.py"],

--- a/tests/unit/fooocus/test_fooocus_input_generation.py
+++ b/tests/unit/fooocus/test_fooocus_input_generation.py
@@ -39,6 +39,7 @@ async def test_fooocus_values_generation(setup_clients):
     assert helm_params["image"] == {
         "repository": "ghcr.io/neuro-inc/fooocus",
         "tag": "latest",
+        "pullPolicy": "IfNotPresent",
     }
 
     assert helm_params["service"] == {

--- a/tests/unit/jupyter/test_jupyter_input_generation.py
+++ b/tests/unit/jupyter/test_jupyter_input_generation.py
@@ -39,6 +39,7 @@ async def test_jupyter_values_generation(setup_clients):
     assert helm_params["image"] == {
         "repository": "ghcr.io/neuro-inc/base",
         "tag": "v25.3.0-runtime",
+        "pullPolicy": "IfNotPresent",
     }
 
     assert helm_params["service"] == {
@@ -156,6 +157,7 @@ async def test_jupyter_custom_image_values_generation(setup_clients):
     assert helm_params["image"] == {
         "repository": "image-name",
         "tag": "latest",
+        "pullPolicy": "IfNotPresent",
     }
     assert helm_params["container"] == {
         "command": ["start-notebook.sh"],

--- a/tests/unit/privategpt/test_privategpt_input_generation.py
+++ b/tests/unit/privategpt/test_privategpt_input_generation.py
@@ -62,6 +62,7 @@ async def test_privategpt_values_generation(setup_clients):
     assert helm_params["image"] == {
         "repository": "ghcr.io/neuro-inc/private-gpt",
         "tag": "latest",
+        "pullPolicy": "IfNotPresent",
     }
     assert helm_params["ingress"]["enabled"] is True
 
@@ -139,6 +140,7 @@ async def test_privategpt_values_generation_custom_temperature(setup_clients):
     assert helm_params["image"] == {
         "repository": "ghcr.io/neuro-inc/private-gpt",
         "tag": "latest",
+        "pullPolicy": "IfNotPresent",
     }
     assert helm_params["ingress"]["enabled"] is True
     assert helm_params["service"] == {

--- a/tests/unit/shell/test_shell_input_generation.py
+++ b/tests/unit/shell/test_shell_input_generation.py
@@ -31,6 +31,7 @@ async def test_shell_values_generation(setup_clients):
     assert helm_params["image"] == {
         "repository": "ghcr.io/neuro-inc/web-shell",
         "tag": "pipelines",
+        "pullPolicy": "IfNotPresent",
     }
 
     assert helm_params["service"] == {

--- a/tests/unit/test_vscode_input_generation.py
+++ b/tests/unit/test_vscode_input_generation.py
@@ -41,6 +41,7 @@ async def test_vscode_values_generation(setup_clients):
     assert helm_params["image"] == {
         "repository": "ghcr.io/neuro-inc/vscode-server",
         "tag": "development",
+        "pullPolicy": "IfNotPresent",
     }
 
     assert helm_params["service"] == {
@@ -91,6 +92,7 @@ async def test_vscode_override_storage_values_generation(setup_clients):
     assert helm_params["image"] == {
         "repository": "ghcr.io/neuro-inc/vscode-server",
         "tag": "development",
+        "pullPolicy": "IfNotPresent",
     }
 
     assert helm_params["service"] == {


### PR DESCRIPTION
This pull request introduces two key updates: support for an optional `app_id` parameter across multiple functions and enhancements to container image handling with the addition of a `pullPolicy` attribute. These changes improve configurability and ensure consistent handling of deployment values. Corresponding unit tests have been updated to validate these enhancements.

### Support for `app_id` Parameter:
* Added an optional `app_id` parameter to multiple functions, including `gen_extra_values`, `app_type_to_vals`, and `get_installation_vals`, enabling applications to specify unique identifiers. (`src/apolo_app_types/helm/apps/base.py` [[1]](diffhunk://#diff-7aae2db47324085cf33a653ff5e765761422cadd94f36307df9ff39a6c8128d6R29) `src/apolo_app_types/helm/apps/common.py` [[2]](diffhunk://#diff-28002666c2fc461137373459616c53f382937984b3d073fc3737f8f2b85da28fR264) `src/apolo_app_types/helm/apps/custom_deployment.py` [[3]](diffhunk://#diff-ce4a4d8545961c4d5c5f952a4c5bbef6c8babc95421477ad2829a1fe9aee4a99R55) `src/apolo_app_types/inputs/args.py` F4de9431L39R39, [[4]](diffhunk://#diff-3f836d893c33b3ca3c0ca40b29e9affd49822a9eab4a14daeadb2b39d9c65235R100)
* Integrated `app_id` into Helm values generation, ensuring it is properly reflected in the output configurations. (`src/apolo_app_types/helm/apps/common.py` [[1]](diffhunk://#diff-28002666c2fc461137373459616c53f382937984b3d073fc3737f8f2b85da28fR304-R307) [[2]](diffhunk://#diff-28002666c2fc461137373459616c53f382937984b3d073fc3737f8f2b85da28fR318-R322) `src/apolo_app_types/helm/apps/custom_deployment.py` [[3]](diffhunk://#diff-ce4a4d8545961c4d5c5f952a4c5bbef6c8babc95421477ad2829a1fe9aee4a99R71)

### Enhancements to Container Image Handling:
* Introduced `ContainerImagePullPolicy` enum and added a `pullPolicy` attribute to the `ContainerImage` class, allowing specification of pull policies (e.g., `Always`, `Never`, `IfNotPresent`). (`src/apolo_app_types/protocols/common/containers.py` [[1]](diffhunk://#diff-7c9904a82bdf8f277ac0952c376b8f23c00b3675107b5b6a7dd6e4105434ec0aR1-R2) [[2]](diffhunk://#diff-7c9904a82bdf8f277ac0952c376b8f23c00b3675107b5b6a7dd6e4105434ec0aR13-R18) [[3]](diffhunk://#diff-7c9904a82bdf8f277ac0952c376b8f23c00b3675107b5b6a7dd6e4105434ec0aR49-R55)
* Updated unit tests across various modules to validate the inclusion of `pullPolicy` in Helm values. (`tests/unit/custom_deployment/test_custom_deployment_input_generation.py` [[1]](diffhunk://#diff-c0e02c74041ea8e01c791076599e74dab2a8b147c4ab588e495b7d24eeab3f46R66) [[2]](diffhunk://#diff-c0e02c74041ea8e01c791076599e74dab2a8b147c4ab588e495b7d24eeab3f46R137) [[3]](diffhunk://#diff-c0e02c74041ea8e01c791076599e74dab2a8b147c4ab588e495b7d24eeab3f46R209) [[4]](diffhunk://#diff-c0e02c74041ea8e01c791076599e74dab2a8b147c4ab588e495b7d24eeab3f46R268) [[5]](diffhunk://#diff-c0e02c74041ea8e01c791076599e74dab2a8b147c4ab588e495b7d24eeab3f46R318) [[6]](diffhunk://#diff-c0e02c74041ea8e01c791076599e74dab2a8b147c4ab588e495b7d24eeab3f46R400) [[7]](diffhunk://#diff-c0e02c74041ea8e01c791076599e74dab2a8b147c4ab588e495b7d24eeab3f46R486) [[8]](diffhunk://#diff-c0e02c74041ea8e01c791076599e74dab2a8b147c4ab588e495b7d24eeab3f46R514-R568) `tests/unit/fooocus/test_fooocus_input_generation.py` [[9]](diffhunk://#diff-3d2187d5e31a38cb135d7e52c90ec6820e691ff92725f73c31a9f3eca7cda608R42) `tests/unit/jupyter/test_jupyter_input_generation.py` [[10]](diffhunk://#diff-aa90b85d3d8c5d8a79103078a1489be950c5bba1fd229d442a0ea72b1ab996dfR42) [[11]](diffhunk://#diff-aa90b85d3d8c5d8a79103078a1489be950c5bba1fd229d442a0ea72b1ab996dfR160) `tests/unit/privategpt/test_privategpt_input_generation.py` [[12]](diffhunk://#diff-6e5218cedf468060f8e752b321f00991d391af73cf16637bf985979d5df8a1ecR65) [[13]](diffhunk://#diff-6e5218cedf468060f8e752b321f00991d391af73cf16637bf985979d5df8a1ecR143) `tests/unit/shell/test_shell_input_generation.py` [[14]](diffhunk://#diff-be12804e4d7ef4ddbf3033aa1ed36bcfd6729eef610cf15bedd01559c03596f4R34) `tests/unit/test_vscode_input_generation.py` [[15]](diffhunk://#diff-0661c96cf192f5cb8c648c138300435ee089fd2c3bc2280df1c85319f396e569R44) [[16]](diffhunk://#diff-0661c96cf192f5cb8c648c138300435ee089fd2c3bc2280df1c85319f396e569R95)