### PR TITLE
MLO-284: Fix output parsing

### DIFF
--- a/src/apolo_app_types/outputs/utils/parsing.py
+++ b/src/apolo_app_types/outputs/utils/parsing.py
@@ -2,8 +2,20 @@ def parse_cli_args(args: list[str]) -> dict[str, str]:
     # Args could be in the form of '--key=value' or '--key value'
     result = {}
     i = 0
-    while i < len(args):
-        arg = args[i]
+    # Before parsing, we need to split strings that might contain both key and value
+    processed_args = []
+    for arg in args:
+        if not arg.startswith("-") and " " in arg:
+            # This is not a standard way to pass args, but we handle it
+            processed_args.extend(arg.split(" ", 1))
+        # Handle cases like '--key value'
+        elif arg.startswith("-") and " " in arg and "=" not in arg:
+            processed_args.extend(arg.split(" ", 1))
+        else:
+            processed_args.append(arg)
+
+    while i < len(processed_args):
+        arg = processed_args[i]
         if not arg.startswith(("-", "--")):
             print("Don't know how to handle argument:", arg)  # noqa: T201
             i += 1
@@ -14,8 +26,8 @@ def parse_cli_args(args: list[str]) -> dict[str, str]:
             key, value = key.split("=", 1)
             result[key] = value
             i += 1
-        elif i + 1 < len(args) and not args[i + 1].startswith("-"):
-            result[key] = args[i + 1]
+        elif i + 1 < len(processed_args) and not processed_args[i + 1].startswith("-"):
+            result[key] = processed_args[i + 1]
             i += 2
         else:
             result[key] = "true"


### PR DESCRIPTION
The fix makes the parser more robust so it can handle both arguments with values and standalone boolean flags, which resolves the error you were seeing in the ArgoCD logs.