### PR TITLE
fix: correct parameter name from 'cmd' to 'command' in JupyterChartValueProcessor

### DIFF
--- a/src/apolo_app_types/helm/apps/jupyter.py
+++ b/src/apolo_app_types/helm/apps/jupyter.py
@@ -124,7 +124,7 @@ class JupyterChartValueProcessor(BaseChartValueProcessor[JupyterAppInputs]):
                     repository=image,
                     tag=tag,
                 ), Container(
-                    cmd=cmd,
+                    command=cmd,
                     args=args,
                     env=env_vars,
                 )


### PR DESCRIPTION
This pull request includes a small change to the `get_container` function in `src/apolo_app_types/helm/apps/jupyter.py`. The change updates the parameter name from `cmd` to `command` to fix generation error