### PR TITLE
Remove unused http_auth field from FooocusSpecificAppInputs 

### DIFF
--- a/src/apolo_app_types/protocols/fooocus.py
+++ b/src/apolo_app_types/protocols/fooocus.py
@@ -33,15 +33,6 @@ class FooocusSpecificAppInputs(BaseModel):
         ).as_json_schema_extra(),
     )
 
-    http_auth: bool = Field(
-        default=True,
-        json_schema_extra=SchemaExtraMetadata(
-            title="HTTP Authentication",
-            description="Enable HTTP authentication to "
-            "restrict access to the Fooocus app.",
-        ).as_json_schema_extra(),
-    )
-
     huggingface_token_secret: OptionalStrOrSecret = Field(  # noqa: N815
         default=None,
         json_schema_extra=SchemaExtraMetadata(

--- a/tests/unit/fooocus/test_fooocus_input_generation.py
+++ b/tests/unit/fooocus/test_fooocus_input_generation.py
@@ -28,7 +28,7 @@ async def test_fooocus_values_generation(setup_clients):
                 clusterName="default",
             ),
             fooocus_specific=FooocusSpecificAppInputs(
-                http_auth=True, huggingface_token_secret="RAW_STRING"
+                huggingface_token_secret="RAW_STRING"
             ),
         ),
         apolo_client=setup_clients,


### PR DESCRIPTION
This pull request removes the `http_auth` field from the `FooocusSpecificAppInputs` model and updates the corresponding test to reflect this change. These updates simplify the model and test by eliminating the HTTP authentication configuration.

### Removal of `http_auth` field:

* [`src/apolo_app_types/protocols/fooocus.py`](diffhunk://#diff-33fe3c9a041d3ecaaefd9ab48ccfaf70c0cc976c24cb58015af316397a15e7ebL36-L44): Removed the `http_auth` field from the `FooocusSpecificAppInputs` model, including its default value and schema metadata. This field was used to enable or disable HTTP authentication for the Fooocus app.

### Test updates:

* [`tests/unit/fooocus/test_fooocus_input_generation.py`](diffhunk://#diff-3d2187d5e31a38cb135d7e52c90ec6820e691ff92725f73c31a9f3eca7cda608L31-R31): Updated the `test_fooocus_values_generation` test by removing the `http_auth` parameter from the `FooocusSpecificAppInputs` instance to align with the model changes.