### PR TITLE
Add OpenWebUI support with inputs, outputs, and chart value processor

### DIFF
--- a/src/apolo_app_types/app_types.py
+++ b/src/apolo_app_types/app_types.py
@@ -10,6 +10,7 @@ from apolo_app_types.protocols.jupyter import JupyterAppInputs
 from apolo_app_types.protocols.lightrag import LightRAGAppInputs
 from apolo_app_types.protocols.llm import LLMInputs
 from apolo_app_types.protocols.mlflow import MLFlowAppInputs
+from apolo_app_types.protocols.openwebui import OpenWebUIAppInputs
 from apolo_app_types.protocols.spark_job import SparkJobInputs
 from apolo_app_types.protocols.vscode import VSCodeAppInputs
 from apolo_app_types.protocols.weaviate import WeaviateInputs
@@ -37,6 +38,7 @@ class AppType(enum.StrEnum):
     ServiceDeployment = "service-deployment"
     SparkJob = "spark-job"
     Superset = "superset"
+    OpenWebUI = "openwebui"
 
     def __repr__(self) -> str:
         return str(self)
@@ -72,6 +74,7 @@ class AppType(enum.StrEnum):
             MLFlowAppInputs: AppType.MLFlow,
             VSCodeAppInputs: AppType.VSCode,
             JupyterAppInputs: AppType.Jupyter,
+            OpenWebUIAppInputs: AppType.OpenWebUI,
         }
 
         input_type = type(inputs)

--- a/src/apolo_app_types/helm/apps/openwebui.py
+++ b/src/apolo_app_types/helm/apps/openwebui.py
@@ -1,0 +1,135 @@
+import typing as t
+
+from yarl import URL
+
+from apolo_app_types import (
+    ApoloFilesMount,
+    ApoloSecret,
+    ContainerImage,
+    CustomDeploymentInputs,
+)
+from apolo_app_types.app_types import AppType
+from apolo_app_types.helm.apps import CustomDeploymentChartValueProcessor
+from apolo_app_types.helm.apps.base import BaseChartValueProcessor
+from apolo_app_types.helm.utils.storage import get_app_data_files_path_url
+from apolo_app_types.protocols.common import (
+    ApoloFilesPath,
+    ApoloMountMode,
+    MountPath,
+    StorageMounts,
+)
+from apolo_app_types.protocols.common.health_check import (
+    HealthCheck,
+    HealthCheckProbesConfig,
+    HTTPHealthCheckConfig,
+)
+from apolo_app_types.protocols.common.k8s import Container, Env, Port
+from apolo_app_types.protocols.common.storage import ApoloMountModes
+from apolo_app_types.protocols.custom_deployment import NetworkingConfig
+from apolo_app_types.protocols.openwebui import OpenWebUIAppInputs
+
+
+class OpenWebUIChartValueProcessor(BaseChartValueProcessor[OpenWebUIAppInputs]):
+    _port = 8080
+
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
+        super().__init__(*args, **kwargs)
+        self.custom_dep_val_processor = CustomDeploymentChartValueProcessor(
+            *args, **kwargs
+        )
+
+    async def _configure_env(
+        self, input_: OpenWebUIAppInputs
+    ) -> dict[str, str | int | ApoloSecret | None]:
+        if not input_.llm_chat_api.hf_model:
+            err_msg = "llm_chat_api.hf_model is required"
+            raise ValueError(err_msg)
+        if not input_.embeddings_api.hf_model:
+            err_msg = "embeddings_api.hf_model is required"
+            raise ValueError(err_msg)
+
+        env = {
+            "OPENAI_API_BASE_URL": str(URL(input_.llm_chat_api.complete_url) / "v1"),
+            "RAG_EMBEDDING_ENGINE": "openai",
+            "RAG_OPENAI_API_BASE_URL": str(
+                URL(input_.embeddings_api.complete_url) / "v1"
+            ),
+            "PGVECTOR_DB_URL": input_.pgvector_user.uri,
+            "DATABASE_SCHEMA": "openwebui",
+        }
+        custom_env = {e.name: e.value for e in input_.openwebui_specific.env}
+        return {**env, **custom_env}
+
+    async def gen_extra_values(
+        self,
+        input_: OpenWebUIAppInputs,
+        app_name: str,
+        namespace: str,
+        app_id: str,
+        app_secrets_name: str,
+        *_: t.Any,
+        **kwargs: t.Any,
+    ) -> dict[str, t.Any]:
+        base_app_storage_path = get_app_data_files_path_url(
+            client=self.client,
+            app_type_name=str(AppType.OpenWebUI.value),
+            app_name=app_name,
+        )
+
+        env = await self._configure_env(input_)
+        custom_deployment = CustomDeploymentInputs(
+            preset=input_.preset,
+            image=ContainerImage(
+                repository="ghcr.io/open-webui/open-webui",
+                tag="git-b5f4c85",
+            ),
+            container=Container(env=[Env(name=k, value=v) for k, v in env.items()]),
+            networking=NetworkingConfig(
+                service_enabled=True,
+                ingress_http=input_.ingress_http,
+                ports=[
+                    Port(name="http", port=self._port),
+                ],
+            ),
+            storage_mounts=StorageMounts(
+                mounts=[
+                    ApoloFilesMount(
+                        storage_uri=ApoloFilesPath(
+                            path=str(base_app_storage_path),
+                        ),
+                        mount_path=MountPath(path="/app/backend/data"),
+                        mode=ApoloMountMode(mode=ApoloMountModes.RW),
+                    )
+                ]
+            ),
+            health_checks=HealthCheckProbesConfig(
+                liveness=HealthCheck(
+                    initial_delay=30,
+                    period=5,
+                    timeout=5,
+                    failure_threshold=20,
+                    health_check_config=HTTPHealthCheckConfig(
+                        path="/health", port=self._port, http_headers=None
+                    ),
+                ),
+                readiness=HealthCheck(
+                    initial_delay=30,
+                    period=5,
+                    timeout=5,
+                    failure_threshold=20,
+                    health_check_config=HTTPHealthCheckConfig(
+                        path="/health", port=self._port, http_headers=None
+                    ),
+                ),
+            ),
+        )
+
+        custom_app_vals = await self.custom_dep_val_processor.gen_extra_values(
+            input_=custom_deployment,
+            app_name=app_name,
+            namespace=namespace,
+            app_id=app_id,
+            app_secrets_name=app_secrets_name,
+            app_type=AppType.OpenWebUI,
+        )
+        return {**custom_app_vals, "labels": {"application": "openwebui"}}

--- a/src/apolo_app_types/inputs/args.py
+++ b/src/apolo_app_types/inputs/args.py
@@ -25,6 +25,7 @@ from apolo_app_types.helm.apps.fooocus import FooocusChartValueProcessor
 from apolo_app_types.helm.apps.jupyter import JupyterChartValueProcessor
 from apolo_app_types.helm.apps.lightrag import LightRAGChartValueProcessor
 from apolo_app_types.helm.apps.mlflow import MLFlowChartValueProcessor
+from apolo_app_types.helm.apps.openwebui import OpenWebUIChartValueProcessor
 from apolo_app_types.helm.apps.postgres import PostgresValueProcessor
 from apolo_app_types.helm.apps.privategpt import PrivateGptChartValueProcessor
 from apolo_app_types.helm.apps.shell import ShellChartValueProcessor
@@ -39,6 +40,7 @@ from apolo_app_types.protocols.dify import DifyAppInputs
 from apolo_app_types.protocols.dockerhub import DockerHubInputs
 from apolo_app_types.protocols.jupyter import JupyterAppInputs
 from apolo_app_types.protocols.mlflow import MLFlowAppInputs
+from apolo_app_types.protocols.openwebui import OpenWebUIAppInputs
 from apolo_app_types.protocols.private_gpt import PrivateGPTAppInputs
 from apolo_app_types.protocols.spark_job import SparkJobInputs
 from apolo_app_types.protocols.superset import SupersetInputs
@@ -74,6 +76,7 @@ async def app_type_to_vals(
         AppType.Shell: ShellChartValueProcessor,
         AppType.Dify: DifyChartValueProcessor,
         AppType.Superset: SupersetChartValueProcessor,
+        AppType.OpenWebUI: OpenWebUIChartValueProcessor,
     }
 
     processor_class = processor_map.get(app_type)
@@ -132,6 +135,7 @@ async def get_installation_vals(
         AppType.VSCode: VSCodeAppInputs,
         AppType.Shell: ShellAppInputs,
         AppType.Superset: SupersetInputs,
+        AppType.OpenWebUI: OpenWebUIAppInputs,
     }
 
     if app_type not in input_type_map:

--- a/src/apolo_app_types/outputs/openwebui.py
+++ b/src/apolo_app_types/outputs/openwebui.py
@@ -1,0 +1,42 @@
+import typing as t
+
+from apolo_app_types.clients.kube import get_service_host_port
+from apolo_app_types.outputs.common import INSTANCE_LABEL
+from apolo_app_types.outputs.utils.ingress import get_ingress_host_port
+from apolo_app_types.protocols.common import RestAPI
+from apolo_app_types.protocols.openwebui import OpenWebUIAppOutputs
+
+
+async def get_openwebui_outputs(
+    helm_values: dict[str, t.Any],
+    app_instance_id: str,
+) -> dict[str, t.Any]:
+    labels = {
+        "application": "openwebui",
+        INSTANCE_LABEL: app_instance_id,
+    }
+    internal_host, internal_port = await get_service_host_port(match_labels=labels)
+    internal_web_app_url = None
+    if internal_host:
+        internal_web_app_url = RestAPI(
+            host=internal_host,
+            port=int(internal_port),
+            base_path="/",
+            protocol="http",
+        )
+
+    host_port = await get_ingress_host_port(match_labels=labels)
+    external_web_app_url = None
+    if host_port:
+        host, port = host_port
+        external_web_app_url = RestAPI(
+            host=host,
+            port=int(port),
+            base_path="/",
+            protocol="https",
+        )
+    outputs = OpenWebUIAppOutputs(
+        internal_web_app_url=internal_web_app_url,
+        external_web_app_url=external_web_app_url,
+    )
+    return outputs.model_dump()

--- a/src/apolo_app_types/outputs/update_outputs.py
+++ b/src/apolo_app_types/outputs/update_outputs.py
@@ -18,6 +18,7 @@ from apolo_app_types.outputs.jupyter import get_jupyter_outputs
 from apolo_app_types.outputs.lightrag import get_lightrag_outputs
 from apolo_app_types.outputs.llm import get_llm_inference_outputs
 from apolo_app_types.outputs.mlflow import get_mlflow_outputs
+from apolo_app_types.outputs.openwebui import get_openwebui_outputs
 from apolo_app_types.outputs.postgres import get_postgres_outputs
 from apolo_app_types.outputs.privategpt import get_privategpt_outputs
 from apolo_app_types.outputs.shell import get_shell_outputs
@@ -147,6 +148,10 @@ async def update_app_outputs(  # noqa: C901
                 conv_outputs = await get_superset_outputs(helm_outputs, app_instance_id)
             case AppType.LightRAG:
                 conv_outputs = await get_lightrag_outputs(helm_outputs, app_instance_id)
+            case AppType.OpenWebUI:
+                conv_outputs = await get_openwebui_outputs(
+                    helm_outputs, app_instance_id
+                )
             case _:
                 # Try loading application postprocessor defined in the app repo
                 postprocessor = load_app_postprocessor(

--- a/src/apolo_app_types/protocols/openwebui.py
+++ b/src/apolo_app_types/protocols/openwebui.py
@@ -1,0 +1,60 @@
+from pydantic import BaseModel, ConfigDict, Field
+
+from apolo_app_types import (
+    AppInputs,
+    AppOutputs,
+    CrunchyPostgresUserCredentials,
+)
+from apolo_app_types.protocols.common import (
+    IngressHttp,
+    Preset,
+    SchemaExtraMetadata,
+)
+from apolo_app_types.protocols.common.k8s import Env
+from apolo_app_types.protocols.common.networking import (
+    RestAPI,
+)
+from apolo_app_types.protocols.common.openai_compat import (
+    OpenAICompatChatAPI,
+    OpenAICompatEmbeddingsAPI,
+)
+
+
+class OpenWebUISpecific(BaseModel):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="PrivateGPT Specific",
+            description="Configure PrivateGPT additional parameters.",
+        ).as_json_schema_extra(),
+    )
+    env: list[Env] = Field(
+        default_factory=list,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Environment Variables",
+            description="List of environment variables to set in"
+            " the OpenWebUI application.",
+        ).as_json_schema_extra(),
+    )
+
+
+class OpenWebUIAppInputs(AppInputs):
+    preset: Preset
+    ingress_http: IngressHttp
+    pgvector_user: CrunchyPostgresUserCredentials
+    embeddings_api: OpenAICompatEmbeddingsAPI
+    llm_chat_api: OpenAICompatChatAPI
+    openwebui_specific: OpenWebUISpecific = Field(
+        default_factory=lambda: OpenWebUISpecific(),
+    )
+
+
+class OpenWebUIAppOutputs(AppOutputs):
+    """
+    PrivateGPT outputs:
+      - internal_web_app_url
+      - external_web_app_url
+    """
+
+    internal_web_app_url: RestAPI | None = None
+    external_web_app_url: RestAPI | None = None

--- a/tests/unit/openwebui/test_openwebui_input_generation.py
+++ b/tests/unit/openwebui/test_openwebui_input_generation.py
@@ -1,0 +1,82 @@
+import pytest
+
+from apolo_app_types import CrunchyPostgresUserCredentials, HuggingFaceModel
+from apolo_app_types.app_types import AppType
+from apolo_app_types.inputs.args import app_type_to_vals
+from apolo_app_types.protocols.common import IngressHttp, Preset
+from apolo_app_types.protocols.common.openai_compat import (
+    OpenAICompatChatAPI,
+    OpenAICompatEmbeddingsAPI,
+)
+from apolo_app_types.protocols.openwebui import OpenWebUIAppInputs
+
+from tests.unit.constants import (
+    APP_ID,
+    APP_SECRETS_NAME,
+)
+
+
+@pytest.mark.asyncio
+async def test_openwebui_values_generation(setup_clients):
+    helm_args, helm_params = await app_type_to_vals(
+        input_=OpenWebUIAppInputs(
+            preset=Preset(name="cpu-small"),
+            ingress_http=IngressHttp(),
+            llm_chat_api=OpenAICompatChatAPI(
+                host="llm-host",
+                port=8000,
+                protocol="https",
+                base_path="/",
+                hf_model=HuggingFaceModel(
+                    model_hf_name="llm-model",
+                    tokenizer_hf_name="llm-tokenizer",
+                ),
+            ),
+            pgvector_user=CrunchyPostgresUserCredentials(
+                user="pgvector_user",
+                password="pgvector_password",
+                host="pgvector_host",
+                port=5432,
+                pgbouncer_host="pgbouncer_host",
+                pgbouncer_port=4321,
+                dbname="db_name",
+            ),
+            embeddings_api=OpenAICompatEmbeddingsAPI(
+                host="text-embeddings-inference-host",
+                port=3000,
+                protocol="https",
+                base_path="/",
+                hf_model=HuggingFaceModel(
+                    model_hf_name="text-embeddings-inference-model",
+                ),
+            ),
+        ),
+        apolo_client=setup_clients,
+        app_type=AppType.OpenWebUI,
+        app_name="openwebui-app",
+        namespace="default-namespace",
+        app_secrets_name=APP_SECRETS_NAME,
+        app_id=APP_ID,
+    )
+    assert helm_params["image"] == {
+        "repository": "ghcr.io/open-webui/open-webui",
+        "tag": "git-b5f4c85",
+        "pullPolicy": "IfNotPresent",
+    }
+    assert helm_params["ingress"]["enabled"] is True
+
+    assert helm_params["service"] == {
+        "enabled": True,
+        "ports": [{"containerPort": 8080, "name": "http"}],
+    }
+    assert helm_params["labels"] == {"application": "openwebui"}
+    assert helm_params["container"]["env"] == [
+        {"name": "OPENAI_API_BASE_URL", "value": "https://llm-host:8000/v1"},
+        {"name": "RAG_EMBEDDING_ENGINE", "value": "openai"},
+        {
+            "name": "RAG_OPENAI_API_BASE_URL",
+            "value": "https://text-embeddings-inference-host:3000/v1",
+        },
+        {"name": "PGVECTOR_DB_URL", "value": ""},  # no url on app install, only outputs
+        {"name": "DATABASE_SCHEMA", "value": "openwebui"},
+    ]


### PR DESCRIPTION
This pull request introduces support for a new application type, `OpenWebUI`, in the `apolo_app_types` module. The changes include adding the necessary protocols, inputs, outputs, and deployment logic to integrate `OpenWebUI` into the existing system. Below is a breakdown of the most important changes grouped by theme.

### Application Type Integration

* Added `OpenWebUIAppInputs` and `OpenWebUIAppOutputs` classes in `src/apolo_app_types/protocols/openwebui.py` to define the inputs and outputs for the `OpenWebUI` application. This includes fields for environment variables, APIs, and database credentials.
* Updated `src/apolo_app_types/app_types.py` to include `OpenWebUI` in the `AppType` enum and its mapping in the `from_app_inputs` method. [[1]](diffhunk://#diff-9b75a8c213738657dc76398bd19b35a96028562f0deac63f828f8f231c2019d4R13) [[2]](diffhunk://#diff-9b75a8c213738657dc76398bd19b35a96028562f0deac63f828f8f231c2019d4R41) [[3]](diffhunk://#diff-9b75a8c213738657dc76398bd19b35a96028562f0deac63f828f8f231c2019d4R77)

### Deployment Logic

* Added `OpenWebUIChartValueProcessor` in `src/apolo_app_types/helm/apps/openwebui.py` to handle Helm chart value generation for deploying `OpenWebUI`. This includes logic for configuring environment variables, networking, storage mounts, and health checks.

### Outputs Handling

* Implemented `get_openwebui_outputs` in `src/apolo_app_types/outputs/openwebui.py` to retrieve internal and external URLs for the `OpenWebUI` application based on Helm chart values.
* Updated `src/apolo_app_types/outputs/update_outputs.py` to include `OpenWebUI` in the `update_app_outputs` function, enabling output processing for this application type. [[1]](diffhunk://#diff-c755e1434d7c19baaafc44d20743e4faa6706f067ead1fca962a38148ffac5eaR21) [[2]](diffhunk://#diff-c755e1434d7c19baaafc44d20743e4faa6706f067ead1fca962a38148ffac5eaR151-R154)