### PR TITLE
Add Literal type annotations for storage types in MLFlow metadata classes

### DIFF
--- a/src/apolo_app_types/protocols/mlflow.py
+++ b/src/apolo_app_types/protocols/mlflow.py
@@ -1,4 +1,5 @@
 from enum import StrEnum
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -21,8 +22,15 @@ class MLFlowMetadataPostgres(AbstractAppFieldType):
     model_config = ConfigDict(
         protected_namespaces=(),
         json_schema_extra=SchemaExtraMetadata(
-            title="Postgres",
-            description="Use PostgreSQL server as metadata storage for MLFlow.",
+            title="Postgres",  # pyright: ignore
+            description="Use PostgreSQL server as metadata storage for MLFlow.",  # pyright: ignore
+        ).as_json_schema_extra(),
+    )
+    storage_type: Literal["postgres"] = Field(
+        default="postgres",
+        json_schema_extra=SchemaExtraMetadata(
+            title="Storage Type",
+            description="Storage type for MLFlow metadata.",
         ).as_json_schema_extra(),
     )
     postgres_uri: PostgresURI
@@ -32,10 +40,17 @@ class MLFlowMetadataSQLite(AbstractAppFieldType):
     model_config = ConfigDict(
         protected_namespaces=(),
         json_schema_extra=SchemaExtraMetadata(
-            title="SQLite",
-            description=(
+            title="SQLite",  # pyright: ignore
+            description=(  # pyright: ignore
                 "Use SQLite on a dedicated block device as metadata store for MLFlow."
             ),
+        ).as_json_schema_extra(),
+    )
+    storage_type: Literal["sqlite"] = Field(
+        default="sqlite",
+        json_schema_extra=SchemaExtraMetadata(
+            title="Storage Type",
+            description="Storage type for MLFlow metadata.",
         ).as_json_schema_extra(),
     )
 


### PR DESCRIPTION
This pull request introduces updates to the `MLFlowMetadataPostgres` and `MLFlowMetadataSQLite` classes in the `src/apolo_app_types/protocols/mlflow.py` file to enhance schema definitions and add a new `storage_type` field for better clarity and validation. Additionally, a minor import adjustment was made.

### Schema Enhancements:

* Added a `storage_type` field with a `Literal` type to both `MLFlowMetadataPostgres` and `MLFlowMetadataSQLite` classes, ensuring explicit storage type definitions (`"postgres"` and `"sqlite"`, respectively). This field includes metadata for schema generation. [[1]](diffhunk://#diff-f0da8b6c414ded50186f14b76c77a733114172a7dfa9a7be497d10d885c5a7d7L24-R33) [[2]](diffhunk://#diff-f0da8b6c414ded50186f14b76c77a733114172a7dfa9a7be497d10d885c5a7d7L35-R55)

### Import Adjustments:

* Added `Literal` from `typing` to support the new `storage_type` field.