### PR TITLE
Parameterize application namespace for outputs

### DIFF
--- a/src/apolo_app_types/cli.py
+++ b/src/apolo_app_types/cli.py
@@ -112,7 +112,7 @@ def run_preprocessor(
             inputs_dict = json.loads(inputs_json)
             inputs_class = load_app_inputs(app_id, inputs_type)
             if not inputs_class:
-                err_msg = f"Unable to find inputs type for {app_id=}"
+                err_msg = f"Unable to find inputs type for {app_id=}, {inputs_type=}"
                 raise ValueError(err_msg)
 
             loaded_inputs = inputs_class.model_validate(inputs_dict)
@@ -120,7 +120,7 @@ def run_preprocessor(
 
             preprocessor_class = load_app_preprocessor(app_id, preprocessor_type)
             if not preprocessor_class:
-                err_msg = f"Unable to find preprocessor type for {app_id=}"
+                err_msg = f"Unable to find preprocessor {app_id=}, {preprocessor_type=}"
                 raise ValueError(err_msg)
 
             await apolo_sdk.login_with_token(

--- a/src/apolo_app_types/clients/kube.py
+++ b/src/apolo_app_types/clients/kube.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import typing
 from pathlib import Path
 
@@ -9,12 +10,15 @@ from kubernetes.client.rest import ApiException  # type: ignore
 logger = logging.getLogger(__name__)
 
 SERVICE_ACC_NAMESPACE_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+NAMESPACE_ENV_VAR = "APOLO_APP_NAMESPACE"
 
 
 def get_current_namespace() -> str:
     """
     Retrieve the current namespace from the Kubernetes service account namespace file.
     """
+    if NAMESPACE_ENV_VAR in os.environ:
+        return os.environ[NAMESPACE_ENV_VAR]
     try:
         with Path.open(Path(SERVICE_ACC_NAMESPACE_FILE)) as f:
             return f.read().strip()


### PR DESCRIPTION
Since in argo-workflow we are running app installer, pre- and post-processors in `argo` namespace, we should parameterize app namespace instead.