### PR TITLE
Add support for sqlite database configuration in OpenWebUI inputs

### DIFF
--- a/src/apolo_app_types/helm/utils/database.py
+++ b/src/apolo_app_types/helm/utils/database.py
@@ -1,0 +1,8 @@
+from apolo_app_types.protocols.postgres import CrunchyPostgresUserCredentials
+
+
+def get_postgres_database_url(credentials: CrunchyPostgresUserCredentials) -> str:
+    if credentials.postgres_uri and credentials.postgres_uri.uri:
+        return credentials.postgres_uri.uri
+
+    return f"postgresql://{credentials.user}:{credentials.password}@{credentials.pgbouncer_host}:{credentials.pgbouncer_port}/{credentials.dbname}"  # noqa: E501

--- a/tests/unit/openwebui/test_openwebui_input_generation.py
+++ b/tests/unit/openwebui/test_openwebui_input_generation.py
@@ -8,7 +8,7 @@ from apolo_app_types.protocols.common.openai_compat import (
     OpenAICompatChatAPI,
     OpenAICompatEmbeddingsAPI,
 )
-from apolo_app_types.protocols.openwebui import OpenWebUIAppInputs
+from apolo_app_types.protocols.openwebui import OpenWebUIAppInputs, PostgresDatabase
 
 from tests.unit.constants import (
     APP_ID,
@@ -32,14 +32,16 @@ async def test_openwebui_values_generation(setup_clients):
                     tokenizer_hf_name="llm-tokenizer",
                 ),
             ),
-            pgvector_user=CrunchyPostgresUserCredentials(
-                user="pgvector_user",
-                password="pgvector_password",
-                host="pgvector_host",
-                port=5432,
-                pgbouncer_host="pgbouncer_host",
-                pgbouncer_port=4321,
-                dbname="db_name",
+            database=PostgresDatabase(
+                credentials=CrunchyPostgresUserCredentials(
+                    user="pgvector_user",
+                    password="pgvector_password",
+                    host="pgvector_host",
+                    port=5432,
+                    pgbouncer_host="pgbouncer_host",
+                    pgbouncer_port=4321,
+                    dbname="db_name",
+                )
             ),
             embeddings_api=OpenAICompatEmbeddingsAPI(
                 host="text-embeddings-inference-host",
@@ -77,10 +79,16 @@ async def test_openwebui_values_generation(setup_clients):
             "name": "RAG_OPENAI_API_BASE_URL",
             "value": "https://text-embeddings-inference-host:3000/v1",
         },
-        {"name": "DATABASE_URL", "value": ""},  # no url on app install, only outputs
+        {
+            "name": "DATABASE_URL",
+            "value": "postgresql://pgvector_user:pgvector_password@pgbouncer_host:4321/db_name",
+        },  # no url on app install, only outputs
         {
             "name": "VECTOR_DB",
             "value": "pgvector",
         },  # no url on app install, only outputs
-        {"name": "PGVECTOR_DB_URL", "value": ""},  # no url on app install, only outputs
+        {
+            "name": "PGVECTOR_DB_URL",
+            "value": "postgresql://pgvector_user:pgvector_password@pgbouncer_host:4321/db_name",
+        },  # no url on app install, only outputs
     ]


### PR DESCRIPTION
We are having issues getting Postgres to work with openwebui because users don't come with permission to change `public` schema. So I added sqlite as database as default.