### PR TITLE
fix openwebui enum type

### DIFF
--- a/src/apolo_app_types/protocols/openwebui.py
+++ b/src/apolo_app_types/protocols/openwebui.py
@@ -26,7 +26,7 @@ from apolo_app_types.protocols.postgres import (
 )
 
 
-class DBTypes(enum.Enum):
+class DBTypes(enum.StrEnum):
     SQLITE = "sqlite"
     POSTGRES = "postgres"
 


### PR DESCRIPTION
Enum types need to be `StrEnum` otherwise we may be a JSON Encoding error with app templates.