### PR TITLE
Add Launchpad application support with inputs, outputs, and configuration

### DIFF
--- a/src/apolo_app_types/__init__.py
+++ b/src/apolo_app_types/__init__.py
@@ -51,6 +51,10 @@ from apolo_app_types.protocols.jupyter import (
     JupyterOutputs,
     JupyterTypes,
 )
+from apolo_app_types.protocols.launchpad import (
+    LaunchpadAppInputs,
+    LaunchpadAppOutputs,
+)
 from apolo_app_types.protocols.lightrag import (
     AnthropicLLMProvider,
     EmbeddingProvider,
@@ -217,4 +221,6 @@ __all__ = [
     "LightRAGAppOutputs",
     "OpenWebUIAppInputs",
     "OpenWebUIAppOutputs",
+    "LaunchpadAppInputs",
+    "LaunchpadAppOutputs",
 ]

--- a/src/apolo_app_types/app_types.py
+++ b/src/apolo_app_types/app_types.py
@@ -39,6 +39,7 @@ class AppType(enum.StrEnum):
     SparkJob = "spark-job"
     Superset = "superset"
     OpenWebUI = "openwebui"
+    Launchpad = "launchpad"
 
     def __repr__(self) -> str:
         return str(self)

--- a/src/apolo_app_types/helm/apps/launchpad.py
+++ b/src/apolo_app_types/helm/apps/launchpad.py
@@ -1,0 +1,30 @@
+import typing as t
+
+from apolo_app_types.helm.apps.base import BaseChartValueProcessor
+from apolo_app_types.protocols.launchpad import LaunchpadAppInputs
+
+
+class LaunchpadChartValueProcessor(BaseChartValueProcessor[LaunchpadAppInputs]):
+    def __init__(self, *args: t.Any, **kwargs: t.Any):
+        super().__init__(*args, **kwargs)
+
+    async def gen_extra_values(
+        self,
+        input_: LaunchpadAppInputs,
+        app_name: str,
+        namespace: str,
+        app_id: str,
+        app_secrets_name: str,
+        *_: t.Any,
+        **kwargs: t.Any,
+    ) -> dict[str, t.Any]:
+        # may need storage later, specially as cache for pulling models
+        # base_app_storage_path = get_app_data_files_path_url(
+        #     client=self.client,
+        #     app_type_name=str(AppType.Launchpad.value),
+        #     app_name=app_name,
+        # )
+
+        return {
+            "LAUNCHPAD_INITIAL_CONFIG": input_.apps_config.model_dump(),
+        }

--- a/src/apolo_app_types/helm/apps/launchpad.py
+++ b/src/apolo_app_types/helm/apps/launchpad.py
@@ -1,12 +1,114 @@
 import typing as t
 
+from apolo_app_types import LLMInputs, TextEmbeddingsInferenceAppInputs
 from apolo_app_types.helm.apps.base import BaseChartValueProcessor
-from apolo_app_types.protocols.launchpad import LaunchpadAppInputs
+from apolo_app_types.protocols.common.hugging_face import HuggingFaceModel
+from apolo_app_types.protocols.launchpad import (
+    HuggingFaceEmbeddingsModel,
+    HuggingFaceLLMModel,
+    LaunchpadAppInputs,
+    PreConfiguredEmbeddingsModels,
+    PreConfiguredLLMModels,
+)
+from apolo_app_types.protocols.postgres import (
+    PGBackupConfig,
+    PGBouncer,
+    PostgresConfig,
+    PostgresDBUser,
+    PostgresInputs,
+)
 
 
 class LaunchpadChartValueProcessor(BaseChartValueProcessor[LaunchpadAppInputs]):
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
+
+    async def get_vllm_inputs(
+        self,
+        input_: LaunchpadAppInputs,
+    ) -> LLMInputs:
+        llm_extra_args: list[str] = []
+        if isinstance(input_.apps_config.llm_config.model, PreConfiguredLLMModels):
+            llm_model = HuggingFaceModel(
+                model_hf_name=input_.apps_config.llm_config.model.value,
+            )
+            match input_.apps_config.llm_config.model:
+                case PreConfiguredLLMModels.MAGISTRAL_24B:
+                    llm_extra_args = [
+                        "--tokenizer_mode=mistral",
+                        "--config_format=mistral",
+                        "--load_format=mistral",
+                        "--tool-call-parser=mistral",
+                        "--enable-auto-tool-choice",
+                        "--tensor-parallel-size=2",
+                    ]
+                case _:
+                    llm_extra_args = []
+        elif isinstance(input_.apps_config.llm_config.model, HuggingFaceLLMModel):
+            llm_model = input_.apps_config.llm_config.model.hf_model
+            llm_extra_args = input_.apps_config.llm_config.model.server_extra_args
+        else:
+            # TODO custom model volumes
+            err = (
+                "Unsupported LLM model type. Expected PreConfiguredLLMModels "
+                "or HuggingFaceModel."
+            )
+            raise ValueError(err)
+
+        return LLMInputs(
+            hugging_face_model=llm_model,
+            tokenizer_hf_name=llm_model.model_hf_name,
+            preset=input_.apps_config.llm_config.llm_preset,
+            server_extra_args=llm_extra_args,
+        )
+
+    async def get_postgres_inputs(
+        self,
+        input_: LaunchpadAppInputs,
+    ) -> PostgresInputs:
+        return PostgresInputs(
+            preset=input_.apps_config.postgres_config.preset,
+            postgres_config=PostgresConfig(
+                instance_replicas=input_.apps_config.postgres_config.replicas,
+                db_users=[
+                    PostgresDBUser(name="launchpad_user", db_names=["launchpad"])
+                ],
+            ),
+            pg_bouncer=PGBouncer(
+                preset=input_.apps_config.postgres_config.preset,
+                replicas=input_.apps_config.postgres_config.replicas,
+            ),
+            backup=PGBackupConfig(enable=True),
+        )
+
+    async def get_text_embeddings_inputs(
+        self,
+        input_: LaunchpadAppInputs,
+    ) -> TextEmbeddingsInferenceAppInputs:
+        extra_args: list[str] = []
+        if isinstance(
+            input_.apps_config.embeddings_config.model,
+            PreConfiguredEmbeddingsModels,
+        ):
+            model_name = input_.apps_config.embeddings_config.model.value
+            model = HuggingFaceModel(
+                model_hf_name=model_name,
+            )
+        elif isinstance(
+            input_.apps_config.embeddings_config.model,
+            HuggingFaceEmbeddingsModel,
+        ):
+            model = input_.apps_config.embeddings_config.model.hf_model
+            extra_args = input_.apps_config.embeddings_config.model.server_extra_args
+        else:
+            err = "Unsupported embeddings model type."
+            raise ValueError(err)
+
+        return TextEmbeddingsInferenceAppInputs(
+            model=model,
+            preset=input_.apps_config.embeddings_config.preset,
+            server_extra_args=extra_args,
+        )
 
     async def gen_extra_values(
         self,
@@ -24,7 +126,20 @@ class LaunchpadChartValueProcessor(BaseChartValueProcessor[LaunchpadAppInputs]):
         #     app_type_name=str(AppType.Launchpad.value),
         #     app_name=app_name,
         # )
+        llm_input = await self.get_vllm_inputs(
+            input_,
+        )
+        postgres_inputs = await self.get_postgres_inputs(
+            input_,
+        )
+        text_embeddings_inputs = await self.get_text_embeddings_inputs(
+            input_,
+        )
 
         return {
-            "LAUNCHPAD_INITIAL_CONFIG": input_.apps_config.model_dump(),
+            "LAUNCHPAD_INITIAL_CONFIG": {
+                "vllm": llm_input.model_dump(),
+                "postgres": postgres_inputs.model_dump(),
+                "text-embeddings": text_embeddings_inputs.model_dump(),
+            },
         }

--- a/src/apolo_app_types/helm/apps/launchpad.py
+++ b/src/apolo_app_types/helm/apps/launchpad.py
@@ -2,6 +2,7 @@ import typing as t
 
 from apolo_app_types import LLMInputs, TextEmbeddingsInferenceAppInputs
 from apolo_app_types.helm.apps.base import BaseChartValueProcessor
+from apolo_app_types.helm.utils.dictionaries import get_nested_values
 from apolo_app_types.protocols.common.hugging_face import HuggingFaceModel
 from apolo_app_types.protocols.launchpad import (
     HuggingFaceEmbeddingsModel,
@@ -138,8 +139,17 @@ class LaunchpadChartValueProcessor(BaseChartValueProcessor[LaunchpadAppInputs]):
 
         return {
             "LAUNCHPAD_INITIAL_CONFIG": {
-                "vllm": llm_input.model_dump(),
-                "postgres": postgres_inputs.model_dump(),
-                "text-embeddings": text_embeddings_inputs.model_dump(),
+                "vllm": get_nested_values(
+                    llm_input.model_dump(),
+                    ["hugging_face_model", "preset", "server_extra_args"],
+                ),
+                "postgres": get_nested_values(
+                    postgres_inputs.model_dump(),
+                    ["preset", "pg_bouncer.preset"],
+                ),
+                "text-embeddings": get_nested_values(
+                    text_embeddings_inputs.model_dump(),
+                    ["model", "preset", "server_extra_args"],
+                ),
             },
         }

--- a/src/apolo_app_types/helm/apps/launchpad.py
+++ b/src/apolo_app_types/helm/apps/launchpad.py
@@ -21,9 +21,6 @@ from apolo_app_types.protocols.postgres import (
 
 
 class LaunchpadChartValueProcessor(BaseChartValueProcessor[LaunchpadAppInputs]):
-    def __init__(self, *args: t.Any, **kwargs: t.Any):
-        super().__init__(*args, **kwargs)
-
     async def get_vllm_inputs(
         self,
         input_: LaunchpadAppInputs,

--- a/src/apolo_app_types/helm/utils/dictionaries.py
+++ b/src/apolo_app_types/helm/utils/dictionaries.py
@@ -1,0 +1,32 @@
+from functools import reduce
+from typing import Any
+
+from apolo_app_types.helm.utils.deep_merging import deep_merge
+
+
+def get_value_from_nested_key(dictionary: dict[str, Any], key: str) -> Any:
+    if "." not in key:
+        return {key: dictionary.get(key)}
+
+    cur_key, next_keys = key.split(".", maxsplit=1)
+    if cur_key in dictionary:
+        return {cur_key: get_value_from_nested_key(dictionary[cur_key], next_keys)}
+    return None
+
+
+def get_nested_values(dictionary: dict[str, Any], keys: list[str]) -> dict[str, Any]:
+    """
+    Retrieve nested keys from a dictionary.
+
+    Args:
+        dictionary (dict): The dictionary to search.
+        keys (list[str]): List of keys to retrieve.
+
+    Returns:
+        dict: A dictionary containing the requested keys and their values.
+    """
+    dicts = []
+    for key in keys:
+        dicts.append(get_value_from_nested_key(dictionary, key))
+
+    return reduce(deep_merge, dicts, {})

--- a/src/apolo_app_types/inputs/args.py
+++ b/src/apolo_app_types/inputs/args.py
@@ -23,6 +23,7 @@ from apolo_app_types.helm.apps.dify import DifyChartValueProcessor
 from apolo_app_types.helm.apps.dockerhub import DockerHubModelChartValueProcessor
 from apolo_app_types.helm.apps.fooocus import FooocusChartValueProcessor
 from apolo_app_types.helm.apps.jupyter import JupyterChartValueProcessor
+from apolo_app_types.helm.apps.launchpad import LaunchpadChartValueProcessor
 from apolo_app_types.helm.apps.lightrag import LightRAGChartValueProcessor
 from apolo_app_types.helm.apps.mlflow import MLFlowChartValueProcessor
 from apolo_app_types.helm.apps.openwebui import OpenWebUIChartValueProcessor
@@ -39,6 +40,7 @@ from apolo_app_types.protocols.custom_deployment import CustomDeploymentInputs
 from apolo_app_types.protocols.dify import DifyAppInputs
 from apolo_app_types.protocols.dockerhub import DockerHubInputs
 from apolo_app_types.protocols.jupyter import JupyterAppInputs
+from apolo_app_types.protocols.launchpad import LaunchpadAppInputs
 from apolo_app_types.protocols.mlflow import MLFlowAppInputs
 from apolo_app_types.protocols.openwebui import OpenWebUIAppInputs
 from apolo_app_types.protocols.private_gpt import PrivateGPTAppInputs
@@ -77,6 +79,7 @@ async def app_type_to_vals(
         AppType.Dify: DifyChartValueProcessor,
         AppType.Superset: SupersetChartValueProcessor,
         AppType.OpenWebUI: OpenWebUIChartValueProcessor,
+        AppType.Launchpad: LaunchpadChartValueProcessor,
     }
 
     processor_class = processor_map.get(app_type)
@@ -136,6 +139,7 @@ async def get_installation_vals(
         AppType.Shell: ShellAppInputs,
         AppType.Superset: SupersetInputs,
         AppType.OpenWebUI: OpenWebUIAppInputs,
+        AppType.Launchpad: LaunchpadAppInputs,
     }
 
     if app_type not in input_type_map:

--- a/src/apolo_app_types/outputs/launchpad.py
+++ b/src/apolo_app_types/outputs/launchpad.py
@@ -1,0 +1,44 @@
+import typing as t
+
+from apolo_app_types.clients.kube import get_service_host_port
+from apolo_app_types.outputs.common import INSTANCE_LABEL
+from apolo_app_types.outputs.utils.ingress import get_ingress_host_port
+from apolo_app_types.protocols.common.networking import HttpApi, RestAPI, ServiceAPI
+from apolo_app_types.protocols.launchpad import LaunchpadAppOutputs
+
+
+async def get_openwebui_outputs(
+    helm_values: dict[str, t.Any],
+    app_instance_id: str,
+) -> dict[str, t.Any]:
+    labels = {
+        "application": "launchpad",
+        INSTANCE_LABEL: app_instance_id,
+    }
+    internal_host, internal_port = await get_service_host_port(match_labels=labels)
+    internal_web_app_url = None
+    if internal_host:
+        internal_web_app_url = RestAPI(
+            host=internal_host,
+            port=int(internal_port),
+            base_path="/",
+            protocol="http",
+        )
+
+    host_port = await get_ingress_host_port(match_labels=labels)
+    external_web_app_url = None
+    if host_port:
+        host, port = host_port
+        external_web_app_url = RestAPI(
+            host=host,
+            port=int(port),
+            base_path="/",
+            protocol="https",
+        )
+    outputs = LaunchpadAppOutputs(
+        web_app_url=ServiceAPI[HttpApi](
+            internal_url=internal_web_app_url,
+            external_url=external_web_app_url,
+        )
+    )
+    return outputs.model_dump()

--- a/src/apolo_app_types/outputs/launchpad.py
+++ b/src/apolo_app_types/outputs/launchpad.py
@@ -7,7 +7,7 @@ from apolo_app_types.protocols.common.networking import HttpApi, RestAPI, Servic
 from apolo_app_types.protocols.launchpad import LaunchpadAppOutputs
 
 
-async def get_openwebui_outputs(
+async def get_launchpad_outputs(
     helm_values: dict[str, t.Any],
     app_instance_id: str,
 ) -> dict[str, t.Any]:

--- a/src/apolo_app_types/outputs/update_outputs.py
+++ b/src/apolo_app_types/outputs/update_outputs.py
@@ -15,6 +15,7 @@ from apolo_app_types.outputs.huggingface_cache import (
     get_app_outputs as get_huggingface_cache_outputs,
 )
 from apolo_app_types.outputs.jupyter import get_jupyter_outputs
+from apolo_app_types.outputs.launchpad import get_launchpad_outputs
 from apolo_app_types.outputs.lightrag import get_lightrag_outputs
 from apolo_app_types.outputs.llm import get_llm_inference_outputs
 from apolo_app_types.outputs.mlflow import get_mlflow_outputs
@@ -152,6 +153,10 @@ async def update_app_outputs(  # noqa: C901
                 conv_outputs = await get_lightrag_outputs(helm_outputs, app_instance_id)
             case AppType.OpenWebUI:
                 conv_outputs = await get_openwebui_outputs(
+                    helm_outputs, app_instance_id
+                )
+            case AppType.Launchpad:
+                conv_outputs = await get_launchpad_outputs(
                     helm_outputs, app_instance_id
                 )
             case AppType.Llama4:

--- a/src/apolo_app_types/protocols/launchpad.py
+++ b/src/apolo_app_types/protocols/launchpad.py
@@ -1,0 +1,147 @@
+import enum
+
+from pydantic import ConfigDict, Field
+
+from apolo_app_types import (
+    AppInputs,
+    AppOutputs,
+    Env,
+    HuggingFaceModel,
+)
+from apolo_app_types.protocols.common.abc_ import AbstractAppFieldType
+from apolo_app_types.protocols.common.networking import (
+    HttpApi,
+    ServiceAPI,
+)
+from apolo_app_types.protocols.common.preset import Preset
+from apolo_app_types.protocols.common.schema_extra import SchemaExtraMetadata
+from apolo_app_types.protocols.common.storage import ApoloFilesPath
+
+
+class PreConfiguredLLMModels(enum.StrEnum):
+    LLAMA_31_8b = "meta-llama/Llama-3.1-8B-Instruct"
+    MAGISTRAL_24B = "unsloth/Magistral-Small-2506-GGUF"
+
+
+class HuggingFaceLLMModel(AbstractAppFieldType):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="HuggingFace LLM Model",
+            description="Specify a custom LLM model to be used in the Launchpad.",
+        ).as_json_schema_extra(),
+    )
+    llm_model: HuggingFaceModel = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Hugging Face Model",
+            description="The Hugging Face model to use for the Launchpad.",
+        ).as_json_schema_extra(),
+    )
+    vllm_extra_args: list[Env] = Field(
+        default_factory=list,
+        json_schema_extra=SchemaExtraMetadata(
+            title="VLLM Extra Arguments",
+            description="Additional arguments to pass to the VLLM runtime.",
+        ).as_json_schema_extra(),
+    )
+
+
+class CustomLLMModel(AbstractAppFieldType):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Custom LLM Model",
+            description="Specify a custom LLM model to be used in the Launchpad.",
+        ).as_json_schema_extra(),
+    )
+    llm_model_name: str = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Model Name",
+            description="The name of the custom LLM model.",
+        ).as_json_schema_extra(),
+    )
+    llm_model_apolo_path: ApoloFilesPath = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Model Path",
+            description="Model path within the Apolo Files.",
+        ).as_json_schema_extra(),
+    )
+    vllm_extra_args: list[str] = Field(
+        default_factory=list,
+        json_schema_extra=SchemaExtraMetadata(
+            title="VLLM Extra Arguments",
+            description="Additional arguments to pass to the VLLM runtime.",
+        ).as_json_schema_extra(),
+    )
+
+
+class LLMConfig(AbstractAppFieldType):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="LLM Configuration",
+            description="Configuration for the LLM model to be used in this Launchpad.",
+        ).as_json_schema_extra(),
+    )
+    llm_model: PreConfiguredLLMModels | HuggingFaceLLMModel | CustomLLMModel = Field(
+        default=PreConfiguredLLMModels.LLAMA_31_8b,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Pre-configured LLM Model",
+            description="Select a pre-configured LLM model for the Launchpad.",
+        ).as_json_schema_extra(),
+    )
+    llm_preset: Preset = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="LLM Preset",
+            description="Preset to use for the LLM model.",
+        ).as_json_schema_extra(),
+    )
+    ui_preset: Preset = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="OpenWebUI Preset",
+            description="Preset to use for OpenWebUI.",
+        ).as_json_schema_extra(),
+    )
+
+
+class AppsConfig(AbstractAppFieldType):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Apps Configuration",
+            description="Configuration for the applications to be launched"
+            " in the Launchpad.",
+        ).as_json_schema_extra(),
+    )
+    llm_config: LLMConfig
+
+
+class LaunchpadConfig(AbstractAppFieldType):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Launchpad Configuration",
+            description="Configuration for the Launchpad application.",
+        ).as_json_schema_extra(),
+    )
+    preset: Preset = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Launchpad Preset",
+            description="Preset to use for the Launchpad application.",
+        ).as_json_schema_extra(),
+    )
+
+
+class LaunchpadAppInputs(AppInputs):
+    launchpad_config: LaunchpadConfig
+    apps_config: AppsConfig
+
+
+class LaunchpadAppOutputs(AppOutputs):
+    web_app_url: ServiceAPI[HttpApi] | None = None

--- a/src/apolo_app_types/protocols/launchpad.py
+++ b/src/apolo_app_types/protocols/launchpad.py
@@ -5,7 +5,6 @@ from pydantic import ConfigDict, Field
 from apolo_app_types import (
     AppInputs,
     AppOutputs,
-    Env,
     HuggingFaceModel,
 )
 from apolo_app_types.protocols.common.abc_ import AbstractAppFieldType
@@ -31,14 +30,14 @@ class HuggingFaceLLMModel(AbstractAppFieldType):
             description="Specify a custom LLM model to be used in the Launchpad.",
         ).as_json_schema_extra(),
     )
-    llm_model: HuggingFaceModel = Field(
+    hf_model: HuggingFaceModel = Field(
         ...,
         json_schema_extra=SchemaExtraMetadata(
             title="Hugging Face Model",
             description="The Hugging Face model to use for the Launchpad.",
         ).as_json_schema_extra(),
     )
-    vllm_extra_args: list[Env] = Field(
+    server_extra_args: list[str] = Field(
         default_factory=list,
         json_schema_extra=SchemaExtraMetadata(
             title="VLLM Extra Arguments",
@@ -55,21 +54,21 @@ class CustomLLMModel(AbstractAppFieldType):
             description="Specify a custom LLM model to be used in the Launchpad.",
         ).as_json_schema_extra(),
     )
-    llm_model_name: str = Field(
+    model_name: str = Field(
         ...,
         json_schema_extra=SchemaExtraMetadata(
             title="Model Name",
             description="The name of the custom LLM model.",
         ).as_json_schema_extra(),
     )
-    llm_model_apolo_path: ApoloFilesPath = Field(
+    model_apolo_path: ApoloFilesPath = Field(
         ...,
         json_schema_extra=SchemaExtraMetadata(
             title="Model Path",
             description="Model path within the Apolo Files.",
         ).as_json_schema_extra(),
     )
-    vllm_extra_args: list[str] = Field(
+    server_extra_args: list[str] = Field(
         default_factory=list,
         json_schema_extra=SchemaExtraMetadata(
             title="VLLM Extra Arguments",
@@ -86,7 +85,7 @@ class LLMConfig(AbstractAppFieldType):
             description="Configuration for the LLM model to be used in this Launchpad.",
         ).as_json_schema_extra(),
     )
-    llm_model: PreConfiguredLLMModels | HuggingFaceLLMModel | CustomLLMModel = Field(
+    model: PreConfiguredLLMModels | HuggingFaceLLMModel | CustomLLMModel = Field(
         default=PreConfiguredLLMModels.LLAMA_31_8b,
         json_schema_extra=SchemaExtraMetadata(
             title="Pre-configured LLM Model",
@@ -109,6 +108,84 @@ class LLMConfig(AbstractAppFieldType):
     )
 
 
+class PostgresConfig(AbstractAppFieldType):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Postgres Configuration",
+            description="Configuration for the Postgres database.",
+        ).as_json_schema_extra(),
+    )
+    preset: Preset = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Postgres Preset",
+            description="Preset to use for the Postgres database.",
+        ).as_json_schema_extra(),
+    )
+    replicas: int = Field(
+        default=2,
+        gt=0,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Postgres Replicas",
+            description="Number of replicas for the Postgres database.",
+        ).as_json_schema_extra(),
+    )
+
+
+class PreConfiguredEmbeddingsModels(enum.StrEnum):
+    BAAI_BGE_M3 = "BAAI/bge-m3"
+
+
+class HuggingFaceEmbeddingsModel(AbstractAppFieldType):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="HuggingFace Embeddings Model",
+            description="Specify a custom embeddings model to be used"
+            " in the Launchpad.",
+        ).as_json_schema_extra(),
+    )
+    hf_model: HuggingFaceModel = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Hugging Face Model",
+            description="The Hugging Face model to use for text embeddings.",
+        ).as_json_schema_extra(),
+    )
+    server_extra_args: list[str] = Field(
+        default_factory=list,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Embeddings Extra Arguments",
+            description="Additional arguments to pass to the embeddings runtime.",
+        ).as_json_schema_extra(),
+    )
+
+
+class TextEmbeddingsConfig(AbstractAppFieldType):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Text Embeddings Configuration",
+            description="Configuration for the text embeddings service.",
+        ).as_json_schema_extra(),
+    )
+    preset: Preset = Field(
+        ...,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Text Embeddings Preset",
+            description="Preset to use for the text embeddings service.",
+        ).as_json_schema_extra(),
+    )
+    model: PreConfiguredEmbeddingsModels | HuggingFaceEmbeddingsModel = Field(
+        default=PreConfiguredEmbeddingsModels.BAAI_BGE_M3,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Embeddings Model",
+            description="The Hugging Face model to use for text embeddings.",
+        ).as_json_schema_extra(),
+    )
+
+
 class AppsConfig(AbstractAppFieldType):
     model_config = ConfigDict(
         protected_namespaces=(),
@@ -119,6 +196,8 @@ class AppsConfig(AbstractAppFieldType):
         ).as_json_schema_extra(),
     )
     llm_config: LLMConfig
+    postgres_config: PostgresConfig
+    embeddings_config: TextEmbeddingsConfig
 
 
 class LaunchpadConfig(AbstractAppFieldType):

--- a/tests/unit/launchpad/test_launchpad_input_generation.py
+++ b/tests/unit/launchpad/test_launchpad_input_generation.py
@@ -11,7 +11,10 @@ from apolo_app_types.protocols.launchpad import (
     LaunchpadAppInputs,
     LaunchpadConfig,
     LLMConfig,
+    PostgresConfig,
+    PreConfiguredEmbeddingsModels,
     PreConfiguredLLMModels,
+    TextEmbeddingsConfig,
 )
 
 from tests.unit.constants import (
@@ -30,10 +33,17 @@ async def test_launchpad_values_generation_with_preconfigured_model(setup_client
             ),
             apps_config=AppsConfig(
                 llm_config=LLMConfig(
-                    llm_model=PreConfiguredLLMModels.LLAMA_31_8b,
+                    model=PreConfiguredLLMModels.LLAMA_31_8b,
                     llm_preset=Preset(name="gpu-small"),
                     ui_preset=Preset(name="cpu-small"),
-                )
+                ),
+                postgres_config=PostgresConfig(
+                    preset=Preset(name="cpu-small"),
+                ),
+                embeddings_config=TextEmbeddingsConfig(
+                    model=PreConfiguredEmbeddingsModels.BAAI_BGE_M3,
+                    preset=Preset(name="gpu-small"),
+                ),
             ),
         ),
         apolo_client=setup_clients,
@@ -48,15 +58,17 @@ async def test_launchpad_values_generation_with_preconfigured_model(setup_client
     assert "LAUNCHPAD_INITIAL_CONFIG" in helm_params
     config = helm_params["LAUNCHPAD_INITIAL_CONFIG"]
 
-    assert config["llm_config"]["llm_model"] == "meta-llama/Llama-3.1-8B-Instruct"
-    assert config["llm_config"]["llm_preset"]["name"] == "gpu-small"
-    assert config["llm_config"]["ui_preset"]["name"] == "cpu-small"
+    assert (
+        config["vllm"]["hugging_face_model"]["model_hf_name"]
+        == "meta-llama/Llama-3.1-8B-Instruct"
+    )
+    assert config["vllm"]["preset"]["name"] == "gpu-small"
 
 
 @pytest.mark.asyncio
 async def test_launchpad_values_generation_with_huggingface_model(setup_clients):
     """Test launchpad helm values generation with a HuggingFace LLM model."""
-    from apolo_app_types import Env, HuggingFaceModel
+    from apolo_app_types import HuggingFaceModel
 
     helm_args, helm_params = await app_type_to_vals(
         input_=LaunchpadAppInputs(
@@ -65,18 +77,25 @@ async def test_launchpad_values_generation_with_huggingface_model(setup_clients)
             ),
             apps_config=AppsConfig(
                 llm_config=LLMConfig(
-                    llm_model=HuggingFaceLLMModel(
-                        llm_model=HuggingFaceModel(
+                    model=HuggingFaceLLMModel(
+                        hf_model=HuggingFaceModel(
                             model_hf_name="microsoft/DialoGPT-medium",
                         ),
-                        vllm_extra_args=[
-                            Env(name="MAX_MODEL_LEN", value="2048"),
-                            Env(name="GPU_MEMORY_UTILIZATION", value="0.9"),
+                        server_extra_args=[
+                            "--max-model-len=2048",
+                            "--gpu-memory-utilization=0.9",
                         ],
                     ),
                     llm_preset=Preset(name="gpu-large"),
                     ui_preset=Preset(name="cpu-medium"),
-                )
+                ),
+                postgres_config=PostgresConfig(
+                    preset=Preset(name="cpu-small"),
+                ),
+                embeddings_config=TextEmbeddingsConfig(
+                    model=PreConfiguredEmbeddingsModels.BAAI_BGE_M3,
+                    preset=Preset(name="gpu-small"),
+                ),
             ),
         ),
         apolo_client=setup_clients,
@@ -90,74 +109,65 @@ async def test_launchpad_values_generation_with_huggingface_model(setup_clients)
     config = helm_params["LAUNCHPAD_INITIAL_CONFIG"]
 
     # Check HuggingFace model configuration
-    llm_model_config = config["llm_config"]["llm_model"]
-    assert llm_model_config["llm_model"]["model_hf_name"] == "microsoft/DialoGPT-medium"
+    llm_model_config = config["vllm"]
+    assert (
+        llm_model_config["hugging_face_model"]["model_hf_name"]
+        == "microsoft/DialoGPT-medium"
+    )
 
     # Check VLLM extra args
-    vllm_args = llm_model_config["vllm_extra_args"]
+    vllm_args = llm_model_config["server_extra_args"]
     assert len(vllm_args) == 2
-    assert vllm_args[0]["name"] == "MAX_MODEL_LEN"
-    assert vllm_args[0]["value"] == "2048"
-    assert vllm_args[1]["name"] == "GPU_MEMORY_UTILIZATION"
-    assert vllm_args[1]["value"] == "0.9"
+    assert vllm_args[0] == "--max-model-len=2048"
+    assert vllm_args[1] == "--gpu-memory-utilization=0.9"
 
     # Check presets
-    assert config["llm_config"]["llm_preset"]["name"] == "gpu-large"
-    assert config["llm_config"]["ui_preset"]["name"] == "cpu-medium"
+    assert config["vllm"]["preset"]["name"] == "gpu-large"
 
 
 @pytest.mark.asyncio
 async def test_launchpad_values_generation_with_custom_model(setup_clients):
     """Test launchpad helm values generation with a custom LLM model."""
-    helm_args, helm_params = await app_type_to_vals(
-        input_=LaunchpadAppInputs(
-            launchpad_config=LaunchpadConfig(
-                preset=Preset(name="cpu-small"),
-            ),
-            apps_config=AppsConfig(
-                llm_config=LLMConfig(
-                    llm_model=CustomLLMModel(
-                        llm_model_name="my-custom-model",
-                        llm_model_apolo_path=ApoloFilesPath(
-                            path="storage://cluster/org/project/models/my-model"
+    # Custom models are not yet supported, so this should raise a ValueError
+    with pytest.raises(ValueError, match="Unsupported LLM model type"):
+        helm_args, helm_params = await app_type_to_vals(
+            input_=LaunchpadAppInputs(
+                launchpad_config=LaunchpadConfig(
+                    preset=Preset(name="cpu-small"),
+                ),
+                apps_config=AppsConfig(
+                    llm_config=LLMConfig(
+                        model=CustomLLMModel(
+                            model_name="my-custom-model",
+                            model_apolo_path=ApoloFilesPath(
+                                path="storage://cluster/org/project/models/my-model"
+                            ),
+                            server_extra_args=[
+                                "--max-model-len",
+                                "4096",
+                                "--tensor-parallel-size",
+                                "2",
+                            ],
                         ),
-                        vllm_extra_args=[
-                            "--max-model-len",
-                            "4096",
-                            "--tensor-parallel-size",
-                            "2",
-                        ],
+                        llm_preset=Preset(name="gpu-xlarge"),
+                        ui_preset=Preset(name="cpu-small"),
                     ),
-                    llm_preset=Preset(name="gpu-xlarge"),
-                    ui_preset=Preset(name="cpu-small"),
-                )
+                    postgres_config=PostgresConfig(
+                        preset=Preset(name="cpu-small"),
+                    ),
+                    embeddings_config=TextEmbeddingsConfig(
+                        model=PreConfiguredEmbeddingsModels.BAAI_BGE_M3,
+                        preset=Preset(name="gpu-small"),
+                    ),
+                ),
             ),
-        ),
-        apolo_client=setup_clients,
-        app_type=AppType.Launchpad,
-        app_name="launchpad-app",
-        namespace="default-namespace",
-        app_secrets_name=APP_SECRETS_NAME,
-        app_id=APP_ID,
-    )
-
-    config = helm_params["LAUNCHPAD_INITIAL_CONFIG"]
-
-    # Check custom model configuration
-    llm_model_config = config["llm_config"]["llm_model"]
-    assert llm_model_config["llm_model_name"] == "my-custom-model"
-    assert (
-        llm_model_config["llm_model_apolo_path"]["path"]
-        == "storage://cluster/org/project/models/my-model"
-    )
-
-    # Check VLLM extra args
-    vllm_args = llm_model_config["vllm_extra_args"]
-    assert vllm_args == ["--max-model-len", "4096", "--tensor-parallel-size", "2"]
-
-    # Check presets
-    assert config["llm_config"]["llm_preset"]["name"] == "gpu-xlarge"
-    assert config["llm_config"]["ui_preset"]["name"] == "cpu-small"
+            apolo_client=setup_clients,
+            app_type=AppType.Launchpad,
+            app_name="launchpad-app",
+            namespace="default-namespace",
+            app_secrets_name=APP_SECRETS_NAME,
+            app_id=APP_ID,
+        )
 
 
 @pytest.mark.asyncio
@@ -170,10 +180,17 @@ async def test_launchpad_values_generation_magistral_model(setup_clients):
             ),
             apps_config=AppsConfig(
                 llm_config=LLMConfig(
-                    llm_model=PreConfiguredLLMModels.MAGISTRAL_24B,
+                    model=PreConfiguredLLMModels.MAGISTRAL_24B,
                     llm_preset=Preset(name="gpu-medium"),
                     ui_preset=Preset(name="cpu-small"),
-                )
+                ),
+                postgres_config=PostgresConfig(
+                    preset=Preset(name="cpu-small"),
+                ),
+                embeddings_config=TextEmbeddingsConfig(
+                    model=PreConfiguredEmbeddingsModels.BAAI_BGE_M3,
+                    preset=Preset(name="gpu-small"),
+                ),
             ),
         ),
         apolo_client=setup_clients,
@@ -186,6 +203,8 @@ async def test_launchpad_values_generation_magistral_model(setup_clients):
 
     config = helm_params["LAUNCHPAD_INITIAL_CONFIG"]
 
-    assert config["llm_config"]["llm_model"] == "unsloth/Magistral-Small-2506-GGUF"
-    assert config["llm_config"]["llm_preset"]["name"] == "gpu-medium"
-    assert config["llm_config"]["ui_preset"]["name"] == "cpu-small"
+    assert (
+        config["vllm"]["hugging_face_model"]["model_hf_name"]
+        == "unsloth/Magistral-Small-2506-GGUF"
+    )
+    assert config["vllm"]["preset"]["name"] == "gpu-medium"

--- a/tests/unit/launchpad/test_launchpad_input_generation.py
+++ b/tests/unit/launchpad/test_launchpad_input_generation.py
@@ -1,0 +1,191 @@
+import pytest
+
+from apolo_app_types.app_types import AppType
+from apolo_app_types.inputs.args import app_type_to_vals
+from apolo_app_types.protocols.common import Preset
+from apolo_app_types.protocols.common.storage import ApoloFilesPath
+from apolo_app_types.protocols.launchpad import (
+    AppsConfig,
+    CustomLLMModel,
+    HuggingFaceLLMModel,
+    LaunchpadAppInputs,
+    LaunchpadConfig,
+    LLMConfig,
+    PreConfiguredLLMModels,
+)
+
+from tests.unit.constants import (
+    APP_ID,
+    APP_SECRETS_NAME,
+)
+
+
+@pytest.mark.asyncio
+async def test_launchpad_values_generation_with_preconfigured_model(setup_clients):
+    """Test launchpad helm values generation with a pre-configured LLM model."""
+    helm_args, helm_params = await app_type_to_vals(
+        input_=LaunchpadAppInputs(
+            launchpad_config=LaunchpadConfig(
+                preset=Preset(name="cpu-small"),
+            ),
+            apps_config=AppsConfig(
+                llm_config=LLMConfig(
+                    llm_model=PreConfiguredLLMModels.LLAMA_31_8b,
+                    llm_preset=Preset(name="gpu-small"),
+                    ui_preset=Preset(name="cpu-small"),
+                )
+            ),
+        ),
+        apolo_client=setup_clients,
+        app_type=AppType.Launchpad,
+        app_name="launchpad-app",
+        namespace="default-namespace",
+        app_secrets_name=APP_SECRETS_NAME,
+        app_id=APP_ID,
+    )
+
+    # Basic helm parameter structure
+    assert "LAUNCHPAD_INITIAL_CONFIG" in helm_params
+    config = helm_params["LAUNCHPAD_INITIAL_CONFIG"]
+
+    assert config["llm_config"]["llm_model"] == "meta-llama/Llama-3.1-8B-Instruct"
+    assert config["llm_config"]["llm_preset"]["name"] == "gpu-small"
+    assert config["llm_config"]["ui_preset"]["name"] == "cpu-small"
+
+
+@pytest.mark.asyncio
+async def test_launchpad_values_generation_with_huggingface_model(setup_clients):
+    """Test launchpad helm values generation with a HuggingFace LLM model."""
+    from apolo_app_types import Env, HuggingFaceModel
+
+    helm_args, helm_params = await app_type_to_vals(
+        input_=LaunchpadAppInputs(
+            launchpad_config=LaunchpadConfig(
+                preset=Preset(name="cpu-small"),
+            ),
+            apps_config=AppsConfig(
+                llm_config=LLMConfig(
+                    llm_model=HuggingFaceLLMModel(
+                        llm_model=HuggingFaceModel(
+                            model_hf_name="microsoft/DialoGPT-medium",
+                        ),
+                        vllm_extra_args=[
+                            Env(name="MAX_MODEL_LEN", value="2048"),
+                            Env(name="GPU_MEMORY_UTILIZATION", value="0.9"),
+                        ],
+                    ),
+                    llm_preset=Preset(name="gpu-large"),
+                    ui_preset=Preset(name="cpu-medium"),
+                )
+            ),
+        ),
+        apolo_client=setup_clients,
+        app_type=AppType.Launchpad,
+        app_name="launchpad-app",
+        namespace="default-namespace",
+        app_secrets_name=APP_SECRETS_NAME,
+        app_id=APP_ID,
+    )
+
+    config = helm_params["LAUNCHPAD_INITIAL_CONFIG"]
+
+    # Check HuggingFace model configuration
+    llm_model_config = config["llm_config"]["llm_model"]
+    assert llm_model_config["llm_model"]["model_hf_name"] == "microsoft/DialoGPT-medium"
+
+    # Check VLLM extra args
+    vllm_args = llm_model_config["vllm_extra_args"]
+    assert len(vllm_args) == 2
+    assert vllm_args[0]["name"] == "MAX_MODEL_LEN"
+    assert vllm_args[0]["value"] == "2048"
+    assert vllm_args[1]["name"] == "GPU_MEMORY_UTILIZATION"
+    assert vllm_args[1]["value"] == "0.9"
+
+    # Check presets
+    assert config["llm_config"]["llm_preset"]["name"] == "gpu-large"
+    assert config["llm_config"]["ui_preset"]["name"] == "cpu-medium"
+
+
+@pytest.mark.asyncio
+async def test_launchpad_values_generation_with_custom_model(setup_clients):
+    """Test launchpad helm values generation with a custom LLM model."""
+    helm_args, helm_params = await app_type_to_vals(
+        input_=LaunchpadAppInputs(
+            launchpad_config=LaunchpadConfig(
+                preset=Preset(name="cpu-small"),
+            ),
+            apps_config=AppsConfig(
+                llm_config=LLMConfig(
+                    llm_model=CustomLLMModel(
+                        llm_model_name="my-custom-model",
+                        llm_model_apolo_path=ApoloFilesPath(
+                            path="storage://cluster/org/project/models/my-model"
+                        ),
+                        vllm_extra_args=[
+                            "--max-model-len",
+                            "4096",
+                            "--tensor-parallel-size",
+                            "2",
+                        ],
+                    ),
+                    llm_preset=Preset(name="gpu-xlarge"),
+                    ui_preset=Preset(name="cpu-small"),
+                )
+            ),
+        ),
+        apolo_client=setup_clients,
+        app_type=AppType.Launchpad,
+        app_name="launchpad-app",
+        namespace="default-namespace",
+        app_secrets_name=APP_SECRETS_NAME,
+        app_id=APP_ID,
+    )
+
+    config = helm_params["LAUNCHPAD_INITIAL_CONFIG"]
+
+    # Check custom model configuration
+    llm_model_config = config["llm_config"]["llm_model"]
+    assert llm_model_config["llm_model_name"] == "my-custom-model"
+    assert (
+        llm_model_config["llm_model_apolo_path"]["path"]
+        == "storage://cluster/org/project/models/my-model"
+    )
+
+    # Check VLLM extra args
+    vllm_args = llm_model_config["vllm_extra_args"]
+    assert vllm_args == ["--max-model-len", "4096", "--tensor-parallel-size", "2"]
+
+    # Check presets
+    assert config["llm_config"]["llm_preset"]["name"] == "gpu-xlarge"
+    assert config["llm_config"]["ui_preset"]["name"] == "cpu-small"
+
+
+@pytest.mark.asyncio
+async def test_launchpad_values_generation_magistral_model(setup_clients):
+    """Test launchpad helm values generation with Magistral pre-configured model."""
+    helm_args, helm_params = await app_type_to_vals(
+        input_=LaunchpadAppInputs(
+            launchpad_config=LaunchpadConfig(
+                preset=Preset(name="cpu-medium"),
+            ),
+            apps_config=AppsConfig(
+                llm_config=LLMConfig(
+                    llm_model=PreConfiguredLLMModels.MAGISTRAL_24B,
+                    llm_preset=Preset(name="gpu-medium"),
+                    ui_preset=Preset(name="cpu-small"),
+                )
+            ),
+        ),
+        apolo_client=setup_clients,
+        app_type=AppType.Launchpad,
+        app_name="launchpad-app",
+        namespace="default-namespace",
+        app_secrets_name=APP_SECRETS_NAME,
+        app_id=APP_ID,
+    )
+
+    config = helm_params["LAUNCHPAD_INITIAL_CONFIG"]
+
+    assert config["llm_config"]["llm_model"] == "unsloth/Magistral-Small-2506-GGUF"
+    assert config["llm_config"]["llm_preset"]["name"] == "gpu-medium"
+    assert config["llm_config"]["ui_preset"]["name"] == "cpu-small"

--- a/tests/unit/launchpad/test_launchpad_input_generation.py
+++ b/tests/unit/launchpad/test_launchpad_input_generation.py
@@ -54,15 +54,46 @@ async def test_launchpad_values_generation_with_preconfigured_model(setup_client
         app_id=APP_ID,
     )
 
-    # Basic helm parameter structure
-    assert "LAUNCHPAD_INITIAL_CONFIG" in helm_params
-    config = helm_params["LAUNCHPAD_INITIAL_CONFIG"]
+    # Validate the complete helm_params structure at once
+    expected_helm_params = {
+        "LAUNCHPAD_INITIAL_CONFIG": {
+            "vllm": {
+                "hugging_face_model": {
+                    "model_hf_name": "meta-llama/Llama-3.1-8B-Instruct",
+                    "hf_token": None,
+                },
+                "preset": {
+                    "name": "gpu-small",
+                },
+                "server_extra_args": [],
+            },
+            "postgres": {
+                "preset": {
+                    "name": "cpu-small",
+                },
+                "pg_bouncer": {
+                    "preset": {
+                        "name": "cpu-small",
+                    },
+                },
+            },
+            "text-embeddings": {
+                "model": {
+                    "model_hf_name": "BAAI/bge-m3",
+                    "hf_token": None,
+                },
+                "preset": {
+                    "name": "gpu-small",
+                },
+                "server_extra_args": [],
+            },
+        },
+        "appTypesImage": {
+            "tag": helm_params["appTypesImage"]["tag"],  # Dynamic tag, use actual value
+        },
+    }
 
-    assert (
-        config["vllm"]["hugging_face_model"]["model_hf_name"]
-        == "meta-llama/Llama-3.1-8B-Instruct"
-    )
-    assert config["vllm"]["preset"]["name"] == "gpu-small"
+    assert helm_params == expected_helm_params
 
 
 @pytest.mark.asyncio
@@ -106,23 +137,49 @@ async def test_launchpad_values_generation_with_huggingface_model(setup_clients)
         app_id=APP_ID,
     )
 
-    config = helm_params["LAUNCHPAD_INITIAL_CONFIG"]
+    # Validate the complete helm_params structure at once
+    expected_helm_params = {
+        "LAUNCHPAD_INITIAL_CONFIG": {
+            "vllm": {
+                "hugging_face_model": {
+                    "model_hf_name": "microsoft/DialoGPT-medium",
+                    "hf_token": None,
+                },
+                "preset": {
+                    "name": "gpu-large",
+                },
+                "server_extra_args": [
+                    "--max-model-len=2048",
+                    "--gpu-memory-utilization=0.9",
+                ],
+            },
+            "postgres": {
+                "preset": {
+                    "name": "cpu-small",
+                },
+                "pg_bouncer": {
+                    "preset": {
+                        "name": "cpu-small",
+                    },
+                },
+            },
+            "text-embeddings": {
+                "model": {
+                    "model_hf_name": "BAAI/bge-m3",
+                    "hf_token": None,
+                },
+                "preset": {
+                    "name": "gpu-small",
+                },
+                "server_extra_args": [],
+            },
+        },
+        "appTypesImage": {
+            "tag": helm_params["appTypesImage"]["tag"],  # Dynamic tag, use actual value
+        },
+    }
 
-    # Check HuggingFace model configuration
-    llm_model_config = config["vllm"]
-    assert (
-        llm_model_config["hugging_face_model"]["model_hf_name"]
-        == "microsoft/DialoGPT-medium"
-    )
-
-    # Check VLLM extra args
-    vllm_args = llm_model_config["server_extra_args"]
-    assert len(vllm_args) == 2
-    assert vllm_args[0] == "--max-model-len=2048"
-    assert vllm_args[1] == "--gpu-memory-utilization=0.9"
-
-    # Check presets
-    assert config["vllm"]["preset"]["name"] == "gpu-large"
+    assert helm_params == expected_helm_params
 
 
 @pytest.mark.asyncio
@@ -201,10 +258,50 @@ async def test_launchpad_values_generation_magistral_model(setup_clients):
         app_id=APP_ID,
     )
 
-    config = helm_params["LAUNCHPAD_INITIAL_CONFIG"]
+    # Validate the complete helm_params structure at once
+    expected_helm_params = {
+        "LAUNCHPAD_INITIAL_CONFIG": {
+            "vllm": {
+                "hugging_face_model": {
+                    "model_hf_name": "unsloth/Magistral-Small-2506-GGUF",
+                    "hf_token": None,
+                },
+                "preset": {
+                    "name": "gpu-medium",
+                },
+                "server_extra_args": [
+                    "--tokenizer_mode=mistral",
+                    "--config_format=mistral",
+                    "--load_format=mistral",
+                    "--tool-call-parser=mistral",
+                    "--enable-auto-tool-choice",
+                    "--tensor-parallel-size=2",
+                ],
+            },
+            "postgres": {
+                "preset": {
+                    "name": "cpu-small",
+                },
+                "pg_bouncer": {
+                    "preset": {
+                        "name": "cpu-small",
+                    },
+                },
+            },
+            "text-embeddings": {
+                "model": {
+                    "model_hf_name": "BAAI/bge-m3",
+                    "hf_token": None,
+                },
+                "preset": {
+                    "name": "gpu-small",
+                },
+                "server_extra_args": [],
+            },
+        },
+        "appTypesImage": {
+            "tag": helm_params["appTypesImage"]["tag"],  # Dynamic tag, use actual value
+        },
+    }
 
-    assert (
-        config["vllm"]["hugging_face_model"]["model_hf_name"]
-        == "unsloth/Magistral-Small-2506-GGUF"
-    )
-    assert config["vllm"]["preset"]["name"] == "gpu-medium"
+    assert helm_params == expected_helm_params

--- a/tests/unit/launchpad/test_launchpad_output_generation.py
+++ b/tests/unit/launchpad/test_launchpad_output_generation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from apolo_app_types.outputs.launchpad import get_openwebui_outputs
+from apolo_app_types.outputs.launchpad import get_launchpad_outputs
 
 
 @pytest.mark.asyncio
@@ -8,7 +8,7 @@ async def test_launchpad_output_generation(
     setup_clients, mock_kubernetes_client, app_instance_id
 ):
     """Test launchpad output generation for web_app_url."""
-    res = await get_openwebui_outputs(
+    res = await get_launchpad_outputs(
         helm_values={
             "LAUNCHPAD_INITIAL_CONFIG": {
                 "vllm": {
@@ -63,7 +63,7 @@ async def test_launchpad_output_generation_no_external_url(
         mock_get_ingress_host_port,
     )
 
-    res = await get_openwebui_outputs(
+    res = await get_launchpad_outputs(
         helm_values={
             "LAUNCHPAD_INITIAL_CONFIG": {
                 "vllm": {
@@ -112,7 +112,7 @@ async def test_launchpad_output_generation_no_service(
         mock_get_ingress_host_port,
     )
 
-    res = await get_openwebui_outputs(
+    res = await get_launchpad_outputs(
         helm_values={
             "LAUNCHPAD_INITIAL_CONFIG": {
                 "vllm": {
@@ -155,7 +155,7 @@ async def test_launchpad_output_generation_custom_ports(
         mock_get_ingress_host_port,
     )
 
-    res = await get_openwebui_outputs(
+    res = await get_launchpad_outputs(
         helm_values={
             "LAUNCHPAD_INITIAL_CONFIG": {
                 "vllm": {

--- a/tests/unit/launchpad/test_launchpad_output_generation.py
+++ b/tests/unit/launchpad/test_launchpad_output_generation.py
@@ -1,0 +1,185 @@
+import pytest
+
+from apolo_app_types.outputs.launchpad import get_openwebui_outputs
+
+
+@pytest.mark.asyncio
+async def test_launchpad_output_generation(
+    setup_clients, mock_kubernetes_client, app_instance_id
+):
+    """Test launchpad output generation for web_app_url."""
+    res = await get_openwebui_outputs(
+        helm_values={
+            "LAUNCHPAD_INITIAL_CONFIG": {
+                "llm_config": {
+                    "llm_model": "meta-llama/Llama-3.1-8B-Instruct",
+                    "llm_preset": {"name": "gpu-small"},
+                    "ui_preset": {"name": "cpu-small"},
+                }
+            },
+        },
+        app_instance_id=app_instance_id,
+    )
+
+    assert res
+    assert "web_app_url" in res
+
+    web_app_url = res["web_app_url"]
+    assert web_app_url["internal_url"] == {
+        "base_path": "/",
+        "host": "app.default-namespace",
+        "port": 80,
+        "protocol": "http",
+        "timeout": 30.0,
+    }
+    assert web_app_url["external_url"] == {
+        "base_path": "/",
+        "host": "example.com",
+        "port": 80,
+        "protocol": "https",
+        "timeout": 30.0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_launchpad_output_generation_no_external_url(
+    setup_clients, mock_kubernetes_client, app_instance_id, monkeypatch
+):
+    """Test launchpad output generation when no external URL is available."""
+
+    async def mock_get_service_host_port(*args, **kwargs):
+        return ("app.default-namespace", 80)
+
+    async def mock_get_ingress_host_port(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "apolo_app_types.outputs.launchpad.get_service_host_port",
+        mock_get_service_host_port,
+    )
+    monkeypatch.setattr(
+        "apolo_app_types.outputs.launchpad.get_ingress_host_port",
+        mock_get_ingress_host_port,
+    )
+
+    res = await get_openwebui_outputs(
+        helm_values={
+            "LAUNCHPAD_INITIAL_CONFIG": {
+                "llm_config": {
+                    "llm_model": "unsloth/Magistral-Small-2506-GGUF",
+                    "llm_preset": {"name": "gpu-medium"},
+                    "ui_preset": {"name": "cpu-small"},
+                }
+            },
+        },
+        app_instance_id=app_instance_id,
+    )
+
+    assert res
+    assert "web_app_url" in res
+
+    web_app_url = res["web_app_url"]
+    assert web_app_url["internal_url"] == {
+        "base_path": "/",
+        "host": "app.default-namespace",
+        "port": 80,
+        "protocol": "http",
+        "timeout": 30.0,
+    }
+    assert web_app_url["external_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_launchpad_output_generation_no_service(
+    setup_clients, mock_kubernetes_client, app_instance_id, monkeypatch
+):
+    """Test launchpad output generation when no service is available."""
+
+    async def mock_get_service_host_port(*args, **kwargs):
+        return (None, None)
+
+    async def mock_get_ingress_host_port(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "apolo_app_types.outputs.launchpad.get_service_host_port",
+        mock_get_service_host_port,
+    )
+    monkeypatch.setattr(
+        "apolo_app_types.outputs.launchpad.get_ingress_host_port",
+        mock_get_ingress_host_port,
+    )
+
+    res = await get_openwebui_outputs(
+        helm_values={
+            "LAUNCHPAD_INITIAL_CONFIG": {
+                "llm_config": {
+                    "llm_model": "meta-llama/Llama-3.1-8B-Instruct",
+                    "llm_preset": {"name": "gpu-small"},
+                    "ui_preset": {"name": "cpu-small"},
+                }
+            },
+        },
+        app_instance_id=app_instance_id,
+    )
+
+    assert res
+    assert "web_app_url" in res
+
+    web_app_url = res["web_app_url"]
+    assert web_app_url["internal_url"] is None
+    assert web_app_url["external_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_launchpad_output_generation_custom_ports(
+    setup_clients, mock_kubernetes_client, app_instance_id, monkeypatch
+):
+    """Test launchpad output generation with custom ports."""
+
+    async def mock_get_service_host_port(*args, **kwargs):
+        return ("launchpad-service.namespace", 8080)
+
+    async def mock_get_ingress_host_port(*args, **kwargs):
+        return ("launchpad.custom.domain", 443)
+
+    monkeypatch.setattr(
+        "apolo_app_types.outputs.launchpad.get_service_host_port",
+        mock_get_service_host_port,
+    )
+    monkeypatch.setattr(
+        "apolo_app_types.outputs.launchpad.get_ingress_host_port",
+        mock_get_ingress_host_port,
+    )
+
+    res = await get_openwebui_outputs(
+        helm_values={
+            "LAUNCHPAD_INITIAL_CONFIG": {
+                "llm_config": {
+                    "llm_model": "meta-llama/Llama-3.1-8B-Instruct",
+                    "llm_preset": {"name": "gpu-large"},
+                    "ui_preset": {"name": "cpu-medium"},
+                }
+            },
+        },
+        app_instance_id=app_instance_id,
+    )
+
+    assert res
+    assert "web_app_url" in res
+
+    web_app_url = res["web_app_url"]
+    assert web_app_url["internal_url"] == {
+        "base_path": "/",
+        "host": "launchpad-service.namespace",
+        "port": 8080,
+        "protocol": "http",
+        "timeout": 30.0,
+    }
+    assert web_app_url["external_url"] == {
+        "base_path": "/",
+        "host": "launchpad.custom.domain",
+        "port": 443,
+        "protocol": "https",
+        "timeout": 30.0,
+    }

--- a/tests/unit/launchpad/test_launchpad_output_generation.py
+++ b/tests/unit/launchpad/test_launchpad_output_generation.py
@@ -11,10 +11,11 @@ async def test_launchpad_output_generation(
     res = await get_openwebui_outputs(
         helm_values={
             "LAUNCHPAD_INITIAL_CONFIG": {
-                "llm_config": {
-                    "llm_model": "meta-llama/Llama-3.1-8B-Instruct",
-                    "llm_preset": {"name": "gpu-small"},
-                    "ui_preset": {"name": "cpu-small"},
+                "vllm": {
+                    "hugging_face_model": {
+                        "model_hf_name": "meta-llama/Llama-3.1-8B-Instruct"
+                    },
+                    "preset": {"name": "gpu-small"},
                 }
             },
         },
@@ -65,10 +66,11 @@ async def test_launchpad_output_generation_no_external_url(
     res = await get_openwebui_outputs(
         helm_values={
             "LAUNCHPAD_INITIAL_CONFIG": {
-                "llm_config": {
-                    "llm_model": "unsloth/Magistral-Small-2506-GGUF",
-                    "llm_preset": {"name": "gpu-medium"},
-                    "ui_preset": {"name": "cpu-small"},
+                "vllm": {
+                    "hugging_face_model": {
+                        "model_hf_name": "unsloth/Magistral-Small-2506-GGUF"
+                    },
+                    "preset": {"name": "gpu-medium"},
                 }
             },
         },
@@ -113,10 +115,11 @@ async def test_launchpad_output_generation_no_service(
     res = await get_openwebui_outputs(
         helm_values={
             "LAUNCHPAD_INITIAL_CONFIG": {
-                "llm_config": {
-                    "llm_model": "meta-llama/Llama-3.1-8B-Instruct",
-                    "llm_preset": {"name": "gpu-small"},
-                    "ui_preset": {"name": "cpu-small"},
+                "vllm": {
+                    "hugging_face_model": {
+                        "model_hf_name": "meta-llama/Llama-3.1-8B-Instruct"
+                    },
+                    "preset": {"name": "gpu-small"},
                 }
             },
         },
@@ -155,10 +158,11 @@ async def test_launchpad_output_generation_custom_ports(
     res = await get_openwebui_outputs(
         helm_values={
             "LAUNCHPAD_INITIAL_CONFIG": {
-                "llm_config": {
-                    "llm_model": "meta-llama/Llama-3.1-8B-Instruct",
-                    "llm_preset": {"name": "gpu-large"},
-                    "ui_preset": {"name": "cpu-medium"},
+                "vllm": {
+                    "hugging_face_model": {
+                        "model_hf_name": "meta-llama/Llama-3.1-8B-Instruct"
+                    },
+                    "preset": {"name": "gpu-large"},
                 }
             },
         },

--- a/tests/unit/utils/test_dictionaries.py
+++ b/tests/unit/utils/test_dictionaries.py
@@ -1,0 +1,8 @@
+from apolo_app_types.helm.utils.dictionaries import get_nested_values
+
+
+def test_get_nested_keys():
+    sample_dict = {"a": 1, "b": {"c": 2, "d": 3}, "e": 4}
+    keys_to_retrieve = ["a", "b.c", "e"]
+    expected_output = {"a": 1, "b": {"c": 2}, "e": 4}
+    assert get_nested_values(sample_dict, keys_to_retrieve) == expected_output


### PR DESCRIPTION
Example `LAUNCHPAD_INITIAL_CONFIG` values generated by `LaunchpadChartValueProcessor`:

```json
{
    "vllm": {
        "hugging_face_model": {
            "model_hf_name": "microsoft/DialoGPT-medium",
            "hf_token": null
        },
        "preset": {
            "name": "gpu-large"
        },
        "server_extra_args": [
            "--max-model-len=2048",
            "--gpu-memory-utilization=0.9"
        ]
    },
    "postgres": {
        "preset": {
            "name": "cpu-small"
        },
        "pg_bouncer": {
            "preset": {
                "name": "cpu-small"
            }
        }
    },
    "text-embeddings": {
        "model": {
            "model_hf_name": "BAAI/bge-m3",
            "hf_token": null
        },
        "preset": {
            "name": "gpu-small"
        },
        "server_extra_args": []
    }
}
```