### PR TITLE
25.7.7 1 - Remove NVIDIA env vars

### DIFF
--- a/src/apolo_app_types/helm/apps/llm.py
+++ b/src/apolo_app_types/helm/apps/llm.py
@@ -42,8 +42,6 @@ class LLMChartValueProcessor(BaseChartValueProcessor[LLMInputs]):
                 "HIP_VISIBLE_DEVICES": device_ids,
                 "ROCR_VISIBLE_DEVICES": device_ids,
             }
-        elif gpu_provider == "nvidia":
-            gpu_env["envNvidia"] = {"CUDA_VISIBLE_DEVICES": device_ids}
 
         return gpu_env
 

--- a/tests/unit/bundles/llama4/test_llama4_input_generation.py
+++ b/tests/unit/bundles/llama4/test_llama4_input_generation.py
@@ -53,7 +53,6 @@ async def test_values_llm_generation_gpu_default_preset(
                 }
             }
         },
-        "envNvidia": {"CUDA_VISIBLE_DEVICES": "0"},
         "preset_name": preset_a100,
         "resources": {
             "requests": {"cpu": "8000.0m", "memory": "0M", "nvidia.com/gpu": "1"},

--- a/tests/unit/llm/test_llm_input_generation.py
+++ b/tests/unit/llm/test_llm_input_generation.py
@@ -120,7 +120,6 @@ async def test_values_llm_generation_gpu(setup_clients, mock_get_preset_gpu):
         "model": {"modelHFName": "test", "tokenizerHFName": "test_tokenizer"},
         "llm": {"modelHFName": "test", "tokenizerHFName": "test_tokenizer"},
         "env": {"HUGGING_FACE_HUB_TOKEN": "test3"},
-        "envNvidia": {"CUDA_VISIBLE_DEVICES": "0"},
         "preset_name": "gpu-small",
         "resources": {
             "requests": {"cpu": "1000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
@@ -401,7 +400,6 @@ async def test_values_llm_generation__storage_integrated(
         "model": {"modelHFName": "test", "tokenizerHFName": ""},
         "llm": {"modelHFName": "test", "tokenizerHFName": ""},
         "env": {"HUGGING_FACE_HUB_TOKEN": "test3"},
-        "envNvidia": {"CUDA_VISIBLE_DEVICES": "0"},
         "preset_name": "gpu-small",
         "resources": {
             "requests": {"cpu": "1000.0m", "memory": "0M", "nvidia.com/gpu": "1"},


### PR DESCRIPTION
This pull request removes support for the `envNvidia` configuration, which previously set the `CUDA_VISIBLE_DEVICES` environment variable for NVIDIA GPUs. The changes affect both the application logic and related unit tests.

This was done because settings these variables cause the same GPU to be scheduled to multiple pods.

### Application Logic Changes:
* Removed the `envNvidia` configuration from the `_configure_gpu_env` method in `src/apolo_app_types/helm/apps/llm.py`, which eliminates setting `CUDA_VISIBLE_DEVICES` for NVIDIA GPUs.

### Unit Test Updates:
* Removed the `envNvidia` entry from the expected environment configuration in the `test_values_llm_generation_gpu` test in `tests/unit/llm/test_llm_input_generation.py`.
* Removed the `envNvidia` entry from the expected environment configuration in the `test_values_llm_generation__storage_integrated` test in `tests/unit/llm/test_llm_input_generation.py`.