### PR TITLE
Add Keycloak configuration and update Launchpad outputs

### DIFF
--- a/src/apolo_app_types/helm/apps/launchpad.py
+++ b/src/apolo_app_types/helm/apps/launchpad.py
@@ -178,6 +178,18 @@ class LaunchpadChartValueProcessor(BaseChartValueProcessor[LaunchpadAppInputs]):
             client=self.client,
         )
         domain = ingress_template.split(".", 1)[1]
+        keycloak_admin_password = _generate_password()
+
+        keycloak_values = {
+            "fullnameOverride": f"launchpad-{app_id}-keycloak",
+            "auth": {
+                "adminPassword": keycloak_admin_password,
+            },
+            "externalDatabase": {"existingSecret": f"launchpad-{app_id}-db-secret"},
+            **values,
+            "service": {"extraLabels": {}},
+        }
+
         return {
             **values,
             "dbSecretName": f"launchpad-{app_id}-db-secret",
@@ -189,14 +201,8 @@ class LaunchpadChartValueProcessor(BaseChartValueProcessor[LaunchpadAppInputs]):
             },
             "dbPassword": _generate_password(),
             "domain": domain,
-            "keycloak": {
-                "fullnameOverride": f"launchpad-{app_id}-keycloak",
-                "auth": {
-                    "adminPassword": _generate_password(),
-                },
-                "externalDatabase": {"existingSecret": f"launchpad-{app_id}-db-secret"},
-                **values,
-            },
+            "keycloak": keycloak_values,  # keeping this for backwards compatibility
+            "mlops-keycloak": keycloak_values,
             "image": {"tag": "25.8.2"},
             "LAUNCHPAD_INITIAL_CONFIG": json.dumps(
                 {

--- a/src/apolo_app_types/outputs/launchpad.py
+++ b/src/apolo_app_types/outputs/launchpad.py
@@ -36,11 +36,45 @@ async def get_launchpad_outputs(
             base_path="/",
             protocol="https",
         )
+
+    # keycloak urls
+    labels = {
+        "application": "keycloak",
+        INSTANCE_LABEL: app_instance_id,
+    }
+
+    host_port = await get_ingress_host_port(match_labels=labels)
+    keycloak_external_web_app_url = None
+    if host_port:
+        host, port = host_port
+        keycloak_external_web_app_url = RestAPI(
+            host=host,
+            port=int(port),
+            base_path="/",
+            protocol="https",
+        )
+
+    internal_host, internal_port = await get_service_host_port(match_labels=labels)
+    keycloak_internal_web_app_url = None
+    if internal_host:
+        keycloak_internal_web_app_url = RestAPI(
+            host=internal_host,
+            port=int(internal_port),
+            base_path="/",
+            protocol="http",
+        )
+
     outputs = LaunchpadAppOutputs(
         web_app_url=ServiceAPI[HttpApi](
             internal_url=internal_web_app_url,
             external_url=external_web_app_url,
         ),
-        keycloak_config=KeycloakConfig(auth_admin_password=keycloak_password),
+        keycloak_config=KeycloakConfig(
+            web_app_url=ServiceAPI[HttpApi](
+                internal_url=keycloak_internal_web_app_url,
+                external_url=keycloak_external_web_app_url,
+            ),
+            auth_admin_password=keycloak_password,
+        ),
     )
     return outputs.model_dump()

--- a/src/apolo_app_types/protocols/launchpad.py
+++ b/src/apolo_app_types/protocols/launchpad.py
@@ -223,6 +223,7 @@ class LaunchpadAppInputs(AppInputs):
 
 
 class KeycloakConfig(AbstractAppFieldType):
+    web_app_url: ServiceAPI[HttpApi]
     auth_admin_password: str = Field(
         ...,
         json_schema_extra=SchemaExtraMetadata(

--- a/tests/unit/launchpad/test_launchpad_input_generation.py
+++ b/tests/unit/launchpad/test_launchpad_input_generation.py
@@ -175,6 +175,31 @@ async def test_launchpad_values_generation_with_preconfigured_model(setup_client
         helm_params["keycloak"]["apolo_app_id"] == expected_helm_params["apolo_app_id"]
     )
 
+    assert "fullnameOverride" in helm_params["mlops-keycloak"]
+    assert (
+        helm_params["mlops-keycloak"]["fullnameOverride"]
+        == f"launchpad-{APP_ID}-keycloak"
+    )
+    assert (
+        helm_params["mlops-keycloak"]["preset_name"]
+        == expected_helm_params["preset_name"]
+    )
+    assert (
+        helm_params["mlops-keycloak"]["resources"] == expected_helm_params["resources"]
+    )
+    assert (
+        helm_params["mlops-keycloak"]["tolerations"]
+        == expected_helm_params["tolerations"]
+    )
+    assert helm_params["mlops-keycloak"]["affinity"] == expected_helm_params["affinity"]
+    assert (
+        helm_params["mlops-keycloak"]["podLabels"] == expected_helm_params["podLabels"]
+    )
+    assert (
+        helm_params["mlops-keycloak"]["apolo_app_id"]
+        == expected_helm_params["apolo_app_id"]
+    )
+
     # Test postgres fields
     assert "fullnameOverride" in helm_params["postgresql"]
     assert helm_params["postgresql"]["fullnameOverride"] == f"launchpad-{APP_ID}-db"


### PR DESCRIPTION
This pull request introduces enhancements to the Launchpad application's Keycloak integration, focusing on improved configuration management and output reporting. The main changes include refactoring how Keycloak values are generated and stored, adding support for a new `mlops-keycloak` configuration for backward compatibility, and expanding the output schema to include Keycloak web app URLs. Additionally, related unit tests have been updated to verify the new configuration structure.

**Keycloak Configuration and Output Enhancements:**

* Refactored Keycloak values generation in `gen_extra_values` to use a shared `keycloak_values` dictionary, ensuring consistent configuration and simplifying password management.
* Added a new `mlops-keycloak` entry in the Helm values, duplicating the Keycloak configuration for backward compatibility with legacy deployments.

**Output Schema Improvements:**

* Expanded the output in `get_launchpad_outputs` to include both internal and external Keycloak web app URLs, making Keycloak endpoints accessible via the application outputs.
* Updated the `KeycloakConfig` data model to include a new `web_app_url` field, which provides structured access to Keycloak service endpoints.

**Unit Test Updates:**

* Enhanced unit tests to verify the presence and correctness of the new `mlops-keycloak` configuration fields, ensuring the backward compatibility and integrity of the Helm values.