### PR TITLE
Add service labels for Launchpad and Keycloak in Helm outputs

### DIFF
--- a/src/apolo_app_types/helm/apps/launchpad.py
+++ b/src/apolo_app_types/helm/apps/launchpad.py
@@ -187,7 +187,14 @@ class LaunchpadChartValueProcessor(BaseChartValueProcessor[LaunchpadAppInputs]):
             },
             "externalDatabase": {"existingSecret": f"launchpad-{app_id}-db-secret"},
             **values,
-            "service": {"extraLabels": {}},
+            "labels": {
+                "application": "launchpad",
+            },
+            "service": {
+                "extraLabels": {
+                    "service": "keycloak",
+                }
+            },
         }
 
         return {

--- a/src/apolo_app_types/outputs/launchpad.py
+++ b/src/apolo_app_types/outputs/launchpad.py
@@ -14,6 +14,7 @@ async def get_launchpad_outputs(
     labels = {
         "application": "launchpad",
         INSTANCE_LABEL: app_instance_id,
+        "service": "launchpad",
     }
     keycloak_password = helm_values["keycloak"]["auth"]["adminPassword"]
     internal_host, internal_port = await get_service_host_port(match_labels=labels)
@@ -41,6 +42,7 @@ async def get_launchpad_outputs(
     labels = {
         "application": "keycloak",
         INSTANCE_LABEL: app_instance_id,
+        "service": "keycloak",
     }
 
     host_port = await get_ingress_host_port(match_labels=labels)


### PR DESCRIPTION
Since this helm chart has multiple services and ingresses, I'm adding a new label to identify each one of them.