### PR TITLE
Change HuggingFaceCache to INLINE MetaType

### DIFF
--- a/src/apolo_app_types/protocols/huggingface_cache.py
+++ b/src/apolo_app_types/protocols/huggingface_cache.py
@@ -1,8 +1,20 @@
+from pydantic import Field
+
 from apolo_app_types.protocols.common import AppInputs, AppOutputs, HuggingFaceCache
+from apolo_app_types.protocols.common.schema_extra import (
+    SchemaExtraMetadata,
+    SchemaMetaType,
+)
 
 
 class HuggingFaceCacheInputs(AppInputs):
-    cache_config: HuggingFaceCache
+    cache_config: HuggingFaceCache = Field(
+        json_schema_extra=SchemaExtraMetadata(
+            title="Hugging Face Cache",
+            description="Configuration for the Hugging Face cache.",
+            meta_type=SchemaMetaType.INLINE,
+        ).as_json_schema_extra()
+    )
 
 
 class HuggingFaceCacheOutputs(AppOutputs):


### PR DESCRIPTION
Refers to a bug where HuggingFaceCache will ask for a HuggingFaceCache integration when installing itself.

Before:

<img width="751" height="229" alt="image" src="https://github.com/user-attachments/assets/20cad750-fde7-45e2-8bff-dfe189eceaed" />

After:

<img width="751" height="388" alt="image" src="https://github.com/user-attachments/assets/d952dfb0-6dd5-4e20-9d1f-1f066f4e5aea" />
