### PR TITLE
Change launchpad service label from "launchpad" to "client" when generating outputs

### DIFF
--- a/src/apolo_app_types/outputs/launchpad.py
+++ b/src/apolo_app_types/outputs/launchpad.py
@@ -18,7 +18,7 @@ async def get_launchpad_outputs(
 
     launchpad_labels = {
         **labels,
-        "service": "launchpad",
+        "service": "client",
     }
     internal_host, internal_port = await get_service_host_port(
         match_labels=launchpad_labels


### PR DESCRIPTION
Now it gets the "launchpad" service url, which is `https://launchpad-<uid>-api.apps.dev.apolo.us/`, but it should get the "client" url without the `-api`: `https://launchpad-<uid>.apps.dev.apolo.us/`

Correct service label to use:

<img width="1140" height="465" alt="image" src="https://github.com/user-attachments/assets/6b773456-132c-43ad-94a1-983becae8169" />

Wrong one currently used:

<img width="1140" height="465" alt="image" src="https://github.com/user-attachments/assets/af7cd9bf-e00e-4177-b54d-7eed53c08e1b" />

