### PR TITLE
MLO-381: MLFlow -> Job App integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,7 @@ test-unit:
 .PHONY: dist
 dist:
 	poetry build --clean
+
+.PHONY: print-schema
+print-schema:
+	poetry run python -c 'import json; from apolo_app_types import $(type_name); print(json.dumps($(type_name).model_json_schema()))'

--- a/src/apolo_app_types/helm/apps/base.py
+++ b/src/apolo_app_types/helm/apps/base.py
@@ -4,7 +4,7 @@ import typing as t
 
 import apolo_sdk
 
-from apolo_app_types import AppInputs
+from apolo_app_types.protocols.common.base import AppInputs
 
 
 logger = logging.getLogger()

--- a/src/apolo_app_types/helm/apps/custom_deployment.py
+++ b/src/apolo_app_types/helm/apps/custom_deployment.py
@@ -1,6 +1,5 @@
 import typing as t
 
-from apolo_app_types import CustomDeploymentInputs, DockerConfigModel
 from apolo_app_types.app_types import AppType
 from apolo_app_types.helm.apps.base import BaseChartValueProcessor
 from apolo_app_types.helm.apps.common import (
@@ -13,6 +12,8 @@ from apolo_app_types.helm.utils.images import (
     get_image_docker_url,
 )
 from apolo_app_types.helm.utils.pods import get_custom_deployment_health_check_values
+from apolo_app_types.protocols.custom_deployment import CustomDeploymentInputs
+from apolo_app_types.protocols.dockerhub import DockerConfigModel
 
 
 class CustomDeploymentChartValueProcessor(

--- a/src/apolo_app_types/helm/apps/llm.py
+++ b/src/apolo_app_types/helm/apps/llm.py
@@ -2,7 +2,6 @@ import typing as t
 
 from apolo_sdk import Preset
 
-from apolo_app_types import LLMInputs
 from apolo_app_types.app_types import AppType
 from apolo_app_types.helm.apps.base import BaseChartValueProcessor
 from apolo_app_types.helm.apps.common import (
@@ -20,6 +19,7 @@ from apolo_app_types.protocols.common import (
 )
 from apolo_app_types.protocols.common.secrets_ import serialize_optional_secret
 from apolo_app_types.protocols.common.storage import ApoloMountModes
+from apolo_app_types.protocols.llm import LLMInputs
 
 
 class LLMChartValueProcessor(BaseChartValueProcessor[LLMInputs]):

--- a/src/apolo_app_types/helm/apps/stable_diffusion.py
+++ b/src/apolo_app_types/helm/apps/stable_diffusion.py
@@ -2,7 +2,6 @@ import typing as t
 
 from apolo_sdk import Preset
 
-from apolo_app_types import StableDiffusionInputs
 from apolo_app_types.app_types import AppType
 from apolo_app_types.helm.apps.base import BaseChartValueProcessor
 from apolo_app_types.helm.apps.common import (
@@ -12,6 +11,7 @@ from apolo_app_types.helm.apps.common import (
 )
 from apolo_app_types.helm.utils.deep_merging import merge_list_of_dicts
 from apolo_app_types.protocols.common.secrets_ import serialize_optional_secret
+from apolo_app_types.protocols.stable_diffusion import StableDiffusionInputs
 
 
 class StableDiffusionChartValueProcessor(

--- a/src/apolo_app_types/protocols/custom_deployment.py
+++ b/src/apolo_app_types/protocols/custom_deployment.py
@@ -1,6 +1,5 @@
 from pydantic import BaseModel, ConfigDict, Field
 
-from apolo_app_types import AppInputs
 from apolo_app_types.protocols.common import (
     AppOutputs,
     AutoscalingHPA,
@@ -12,6 +11,7 @@ from apolo_app_types.protocols.common import (
     StorageMounts,
 )
 from apolo_app_types.protocols.common.abc_ import AbstractAppFieldType
+from apolo_app_types.protocols.common.base import AppInputs
 from apolo_app_types.protocols.common.health_check import (
     HealthCheckProbesConfig,
 )

--- a/src/apolo_app_types/protocols/job.py
+++ b/src/apolo_app_types/protocols/job.py
@@ -438,7 +438,7 @@ class JobIntegrationsConfig(AbstractAppFieldType):
     model_config = ConfigDict(
         protected_namespaces=(),
         json_schema_extra=SchemaExtraMetadata(
-            title="Job Integrations",
+            title="Integrations",
             description="Integrate your job with applications.",
             is_advanced_field=True,
         ).as_json_schema_extra(),
@@ -449,10 +449,10 @@ class JobIntegrationsConfig(AbstractAppFieldType):
         json_schema_extra=SchemaExtraMetadata(
             title="MLFlow Integration",
             description=(
-                "Preconfigure job to access MLFlow server. "
-                "If enabled, the job will recieve MLFlow tracking server URL "
-                "as an environment variable MLFLOW_TRACKING_URI and will be authorized "
-                "to access it."
+                "Preconfigure the job to access the MLflow server. "
+                "If enabled, the job will receive the MLflow tracking server URL"
+                "as the MLFLOW_TRACKING_URI environment variable and will be "
+                "authorized to access it."
             ),
             meta_type=SchemaMetaType.INTEGRATION,
         ).as_json_schema_extra(),

--- a/src/apolo_app_types/protocols/job.py
+++ b/src/apolo_app_types/protocols/job.py
@@ -10,11 +10,13 @@ from apolo_app_types.protocols.common import (
     AppInputs,
     AppOutputs,
     SchemaExtraMetadata,
+    SchemaMetaType,
 )
 from apolo_app_types.protocols.common.k8s import Env
 from apolo_app_types.protocols.common.preset import Preset
 from apolo_app_types.protocols.common.secrets_ import ApoloSecret
 from apolo_app_types.protocols.common.storage import StorageMounts
+from apolo_app_types.protocols.mlflow import MLFlowTrackingServerURL
 
 
 class JobPriority(StrEnum):
@@ -430,6 +432,33 @@ class ContainerHTTPServer(AbstractAppFieldType):
     )
 
 
+class JobIntegrationsConfig(AbstractAppFieldType):
+    """Integrations configuration."""
+
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Job Integrations",
+            description="Integrate your job with applications.",
+            is_advanced_field=True,
+        ).as_json_schema_extra(),
+    )
+
+    mlflow_integration: MLFlowTrackingServerURL = Field(
+        default=MLFlowTrackingServerURL(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="MLFlow Integration",
+            description=(
+                "Preconfigure job to access MLFlow server. "
+                "If enabled, the job will recieve MLFlow tracking server URL "
+                "as an environment variable MLFLOW_TRACKING_URI and will be authorized "
+                "to access it."
+            ),
+            meta_type=SchemaMetaType.INTEGRATION,
+        ).as_json_schema_extra(),
+    )
+
+
 class JobAppInput(AppInputs):
     """Top-level configuration for a generic batch/Job container."""
 
@@ -452,6 +481,10 @@ class JobAppInput(AppInputs):
 
     networking: JobNetworkingConfig = Field(
         default_factory=JobNetworkingConfig,
+    )
+
+    integrations: JobIntegrationsConfig = Field(
+        default_factory=JobIntegrationsConfig,
     )
 
     scheduling: JobSchedulingConfig = Field(

--- a/src/apolo_app_types/protocols/mlflow.py
+++ b/src/apolo_app_types/protocols/mlflow.py
@@ -112,6 +112,7 @@ class MLFlowTrackingServerURL(ServiceAPI[RestAPI]):
         json_schema_extra=SchemaExtraMetadata(
             title="MLFlow Server URL",
             description="The URL to access the MLFlow server.",
+            meta_type=SchemaMetaType.INTEGRATION,
         ).as_json_schema_extra(),
     )
 

--- a/src/apolo_app_types/protocols/postgres.py
+++ b/src/apolo_app_types/protocols/postgres.py
@@ -6,11 +6,12 @@ from typing import Literal
 
 from pydantic import ConfigDict, Field, model_validator
 
-from apolo_app_types import AppInputs, Bucket
 from apolo_app_types.protocols.common import (
     AbstractAppFieldType,
+    AppInputs,
     AppOutputs,
     AppOutputsDeployer,
+    Bucket,
     Preset,
     SchemaExtraMetadata,
     SchemaMetaType,

--- a/tests/unit/job_app/test_job_integrations.py
+++ b/tests/unit/job_app/test_job_integrations.py
@@ -1,0 +1,108 @@
+import pytest
+
+from apolo_app_types.job_utils import prepare_job_run_params
+from apolo_app_types.protocols.common import ApoloSecret, Env, Preset, RestAPI
+from apolo_app_types.protocols.job import (
+    JobAppInput,
+    JobImageConfig,
+    JobIntegrationsConfig,
+    JobResourcesConfig,
+    JobSchedulingConfig,
+)
+from apolo_app_types.protocols.mlflow import MLFlowTrackingServerURL
+
+
+def test_prepare_job_with_mlflow_integration(setup_clients, mock_get_preset_cpu):
+    job_input = JobAppInput(
+        image=JobImageConfig(image="python:3.9"),
+        resources=JobResourcesConfig(preset=Preset(name="cpu-small")),
+        scheduling=JobSchedulingConfig(max_run_time_minutes=0),
+        integrations=JobIntegrationsConfig(
+            mlflow_integration=MLFlowTrackingServerURL(
+                internal_url=RestAPI(host="mlflow.example.com")
+            )
+        ),
+    )
+
+    client = setup_clients
+
+    result = prepare_job_run_params(
+        job_input=job_input,
+        app_instance_id="test-instance-123",
+        app_instance_name="test-app",
+        org_name="test-org",
+        project_name="test-project",
+        client=client,
+    )
+
+    assert (
+        result.container.env["MLFLOW_TRACKING_URI"] == "http://mlflow.example.com:80/"
+    )
+
+
+def test_prepare_job_with_mlflow_integration_conflicts_with_env(
+    setup_clients, mock_get_preset_cpu
+):
+    job_input = JobAppInput(
+        image=JobImageConfig(
+            image="python:3.9",
+            env=[Env(name="MLFLOW_TRACKING_URI", value="http://other.example.com:80/")],
+        ),
+        resources=JobResourcesConfig(preset=Preset(name="cpu-small")),
+        scheduling=JobSchedulingConfig(max_run_time_minutes=0),
+        integrations=JobIntegrationsConfig(
+            mlflow_integration=MLFlowTrackingServerURL(
+                internal_url=RestAPI(host="mlflow.example.com")
+            )
+        ),
+    )
+
+    client = setup_clients
+
+    with pytest.raises(
+        ValueError,
+        match="MLFLOW_TRACKING_URI env var conflicts with MLFlow integration.",
+    ):
+        prepare_job_run_params(
+            job_input=job_input,
+            app_instance_id="test-instance-123",
+            app_instance_name="test-app",
+            org_name="test-org",
+            project_name="test-project",
+            client=client,
+        )
+
+
+def test_prepare_job_with_mlflow_integration_conflicts_with_secret_env(
+    setup_clients, mock_get_preset_cpu
+):
+    job_input = JobAppInput(
+        image=JobImageConfig(
+            image="python:3.9",
+            secret_env=[
+                Env(name="MLFLOW_TRACKING_URI", value=ApoloSecret(key="somethinbg"))
+            ],
+        ),
+        resources=JobResourcesConfig(preset=Preset(name="cpu-small")),
+        scheduling=JobSchedulingConfig(max_run_time_minutes=0),
+        integrations=JobIntegrationsConfig(
+            mlflow_integration=MLFlowTrackingServerURL(
+                internal_url=RestAPI(host="mlflow.example.com")
+            )
+        ),
+    )
+
+    client = setup_clients
+
+    with pytest.raises(
+        ValueError,
+        match="MLFLOW_TRACKING_URI env var conflicts with MLFlow integration.",
+    ):
+        prepare_job_run_params(
+            job_input=job_input,
+            app_instance_id="test-instance-123",
+            app_instance_name="test-app",
+            org_name="test-org",
+            project_name="test-project",
+            client=client,
+        )

--- a/tests/unit/job_app/test_job_utils.py
+++ b/tests/unit/job_app/test_job_utils.py
@@ -27,32 +27,23 @@ from apolo_app_types.protocols.job import (
 )
 
 
-def test_prepare_job_run_params_minimal():
+def test_prepare_job_run_params_minimal(setup_clients, mock_get_preset_cpu):
     """Test prepare_job_run_params with minimal configuration."""
     job_input = JobAppInput(
         image=JobImageConfig(image="python:3.9"),
         resources=JobResourcesConfig(preset=Preset(name="cpu-small")),
     )
 
-    client = MagicMock()
+    client = setup_clients
 
-    with patch("apolo_app_types.helm.apps.common.get_preset") as mock_get_preset:
-        mock_preset = apolo_sdk.Preset(
-            cpu=2.0,
-            memory=8,
-            credits_per_hour=Decimal("0.05"),
-            available_resource_pool_names=("cpu_pool",),
-        )
-        mock_get_preset.return_value = mock_preset
-
-        result = prepare_job_run_params(
-            job_input=job_input,
-            app_instance_id="test-instance-123",
-            app_instance_name="test-app",
-            org_name="test-org",
-            project_name="test-project",
-            client=client,
-        )
+    result = prepare_job_run_params(
+        job_input=job_input,
+        app_instance_id="test-instance-123",
+        app_instance_name="test-app",
+        org_name="test-org",
+        project_name="test-project",
+        client=client,
+    )
 
     assert isinstance(result, JobRunParams)
     assert result.name == "test-app-test-ins"  # truncated to 8 chars
@@ -78,7 +69,7 @@ def test_prepare_job_run_params_minimal():
     assert container.working_dir is None  # Empty string converted to None
 
 
-def test_prepare_job_run_params_with_custom_name():
+def test_prepare_job_run_params_with_custom_name(setup_clients, mock_get_preset_cpu):
     """Test prepare_job_run_params with custom job name."""
     job_input = JobAppInput(
         image=JobImageConfig(image="python:3.9"),
@@ -86,25 +77,16 @@ def test_prepare_job_run_params_with_custom_name():
         metadata=JobMetadataConfig(name="my-custom-job"),
     )
 
-    client = MagicMock()
+    client = setup_clients
 
-    with patch("apolo_app_types.helm.apps.common.get_preset") as mock_get_preset:
-        mock_preset = apolo_sdk.Preset(
-            cpu=2.0,
-            memory=8,
-            credits_per_hour=Decimal("0.05"),
-            available_resource_pool_names=("cpu_pool",),
-        )
-        mock_get_preset.return_value = mock_preset
-
-        result = prepare_job_run_params(
-            job_input=job_input,
-            app_instance_id="test-instance-123",
-            app_instance_name="test-app",
-            org_name="test-org",
-            project_name="test-project",
-            client=client,
-        )
+    result = prepare_job_run_params(
+        job_input=job_input,
+        app_instance_id="test-instance-123",
+        app_instance_name="test-app",
+        org_name="test-org",
+        project_name="test-project",
+        client=client,
+    )
 
     assert result.name == "my-custom-job"
 
@@ -265,7 +247,7 @@ def test_prepare_job_run_params_with_secret_volumes():
     assert sf2.container_path == "/secrets/db-credentials"
 
 
-def test_prepare_job_run_params_with_all_options():
+def test_prepare_job_run_params_with_all_options(setup_clients, mock_get_preset_gpu):
     """Test prepare_job_run_params with all configuration options."""
     job_input = JobAppInput(
         image=JobImageConfig(
@@ -298,25 +280,16 @@ def test_prepare_job_run_params_with_all_options():
         ),
     )
 
-    client = MagicMock()
+    client = setup_clients
 
-    with patch("apolo_app_types.helm.apps.common.get_preset") as mock_get_preset:
-        mock_preset = apolo_sdk.Preset(
-            cpu=4.0,
-            memory=16,
-            credits_per_hour=Decimal("0.2"),
-            available_resource_pool_names=("gpu_pool",),
-        )
-        mock_get_preset.return_value = mock_preset
-
-        result = prepare_job_run_params(
-            job_input=job_input,
-            app_instance_id="test-instance-123",
-            app_instance_name="test-app",
-            org_name="test-org",
-            project_name="test-project",
-            client=client,
-        )
+    result = prepare_job_run_params(
+        job_input=job_input,
+        app_instance_id="test-instance-123",
+        app_instance_name="test-app",
+        org_name="test-org",
+        project_name="test-project",
+        client=client,
+    )
 
     assert result.name == "full-featured-job"
     assert result.description == "A job with all features enabled"


### PR DESCRIPTION
1. added integration to MLFlow server
2. fixed couple of circular imports
3. added dev shortcut `make print-schema` to print schema to STDOUT. e.g. `make print-schema type_name=JobAppInput`

This effectively adds another advanced section with list of supported integrations:
<img width="842" height="900" alt="image" src="https://github.com/user-attachments/assets/3f251eaf-67d7-4574-a883-ddfe761c2bb8" />

<img width="684" height="397" alt="image" src="https://github.com/user-attachments/assets/e6b04869-971e-4e41-bd4e-95ef9c4697e7" />
