### PR TITLE
Refactor ingress middleware annotation handling and update related tests

### DIFF
--- a/src/apolo_app_types/helm/apps/ingress.py
+++ b/src/apolo_app_types/helm/apps/ingress.py
@@ -178,11 +178,11 @@ async def get_grpc_ingress_values(
 
 
 async def append_ingress_middleware_annotations(
-    current_annotations: dict[str, t.Any], namespace: str, middleware_name: str
+    current_annotations: dict[str, t.Any], middleware_name: str
 ) -> dict[str, t.Any]:
     curr_annot = deepcopy(current_annotations)
 
-    middleware_annot = f"{namespace}-{middleware_name}@kubernetescrd"
+    middleware_annot = f"{middleware_name}@kubernetescrd"
 
     if MIDDLEWARE_ANNOTATION_KEY in curr_annot:
         curr_annot[MIDDLEWARE_ANNOTATION_KEY] += f",{middleware_annot}"

--- a/src/apolo_app_types/helm/apps/openwebui.py
+++ b/src/apolo_app_types/helm/apps/openwebui.py
@@ -149,7 +149,6 @@ class OpenWebUIChartValueProcessor(BaseChartValueProcessor[OpenWebUIAppInputs]):
                 "annotations"
             ] = await append_ingress_middleware_annotations(
                 custom_app_vals["ingress"]["annotations"],
-                namespace,
                 input_.networking_config.advanced_networking.ingress_middleware.name,
             )
         return {**custom_app_vals, "labels": {"application": "openwebui"}}

--- a/src/apolo_app_types/protocols/common/ingress.py
+++ b/src/apolo_app_types/protocols/common/ingress.py
@@ -74,9 +74,10 @@ class AuthIngressMiddleware(IngressMiddleware):
     )
     name: str = Field(
         ...,
+        pattern=r"^platform",
         json_schema_extra=SchemaExtraMetadata(
             title="Middleware Name",
-            description="Name of the authentication middleware to"
+            description="Name of the authentication middleware (with namespace) to"
             " apply to ingress traffic.",
         ).as_json_schema_extra(),
     )

--- a/tests/unit/openwebui/test_openwebui_input_generation.py
+++ b/tests/unit/openwebui/test_openwebui_input_generation.py
@@ -114,7 +114,7 @@ async def test_openwebui_values_generation_with_ingress_middleware(setup_clients
                 ingress_http=IngressHttp(),
                 advanced_networking=AdvancedNetworkConfig(
                     ingress_middleware=AuthIngressMiddleware(
-                        name="custom-auth-middleware"
+                        name="platform-custom-auth-middleware"
                     )
                 ),
             ),
@@ -173,9 +173,7 @@ async def test_openwebui_values_generation_with_ingress_middleware(setup_clients
     middleware_annotation = helm_params["ingress"]["annotations"][
         "traefik.ingress.kubernetes.io/router.middlewares"
     ]
-    expected_custom_middleware = (
-        "default-namespace-custom-auth-middleware@kubernetescrd"
-    )
+    expected_custom_middleware = "platform-custom-auth-middleware@kubernetescrd"
 
     # Should contain our custom middleware
     assert expected_custom_middleware in middleware_annotation


### PR DESCRIPTION
Right now all Traefik middlewares must reside in `platform` namespace, so I modified the logic in app-types to always check if the used middleware is there and not to add the current app namespace to the middleware name.