### PR TITLE
Refactor installed apps handling to use InstalledApps model and update type annotations

### DIFF
--- a/src/apolo_app_types/outputs/launchpad.py
+++ b/src/apolo_app_types/outputs/launchpad.py
@@ -7,10 +7,14 @@ from apolo_app_types.outputs.common import INSTANCE_LABEL
 from apolo_app_types.outputs.utils.ingress import get_ingress_host_port
 from apolo_app_types.protocols.apps import AppInstance
 from apolo_app_types.protocols.common.networking import HttpApi, ServiceAPI, WebApp
-from apolo_app_types.protocols.launchpad import KeycloakConfig, LaunchpadAppOutputs
+from apolo_app_types.protocols.launchpad import (
+    InstalledApps,
+    KeycloakConfig,
+    LaunchpadAppOutputs,
+)
 
 
-async def _get_installed_apps(admin_password: str, api: HttpApi) -> list[AppInstance]:
+async def _get_installed_apps(admin_password: str, api: HttpApi) -> InstalledApps:
     async with httpx.AsyncClient() as client:
         response = await client.get(
             f"{api.protocol}://{api.host}:{api.port}{api.base_path}instances",
@@ -27,7 +31,7 @@ async def _get_installed_apps(admin_password: str, api: HttpApi) -> list[AppInst
             )
             installed_apps.append(app_instance)
 
-        return installed_apps
+        return InstalledApps(app_list=installed_apps)
 
 
 async def get_launchpad_outputs(

--- a/src/apolo_app_types/protocols/launchpad.py
+++ b/src/apolo_app_types/protocols/launchpad.py
@@ -276,6 +276,23 @@ class KeycloakConfig(AbstractAppFieldType):
     )
 
 
+class InstalledApps(AbstractAppFieldType):
+    model_config = ConfigDict(
+        protected_namespaces=(),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Installed Applications",
+            description="Applications that are installed via the Launchpad.",
+        ).as_json_schema_extra(),
+    )
+    app_list: list[AppInstance] = Field(
+        default_factory=list,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Installed Applications",
+            description="List of applications installed via the Launchpad.",
+        ).as_json_schema_extra(),
+    )
+
+
 class LaunchpadAppOutputs(AppOutputs):
     keycloak_config: KeycloakConfig | None = None
-    installed_apps: list[AppInstance] | None = None
+    installed_apps: InstalledApps | None = None


### PR DESCRIPTION
Because AppOutputs cannot have `primittive` types in the first level in Platform Apps.

