### PR TITLE
feat(app-types): add x-custom-validators schema metadata

### DIFF
--- a/src/apolo_app_types/protocols/common/__init__.py
+++ b/src/apolo_app_types/protocols/common/__init__.py
@@ -9,7 +9,12 @@ from .autoscaling import AutoscalingHPA
 from .base import AppInputs, AppOutputs
 from .buckets import Bucket
 from .containers import ContainerImage
-from .custom_validators import PRESET_VALIDATOR_NAME
+from .custom_validators import (
+    PRESET_VALIDATOR_NAME,
+    CustomValidatorSpec,
+    PresetValidatorConfig,
+    preset_validator,
+)
 from .hugging_face import HuggingFaceCache, HuggingFaceModel, HuggingFaceToken
 from .ingress import (
     BaseIngress,
@@ -76,6 +81,9 @@ __all__ = [
     "SchemaMetaType",
     "X_CUSTOM_VALIDATORS_FIELD_NAME",
     "PRESET_VALIDATOR_NAME",
+    "PresetValidatorConfig",
+    "CustomValidatorSpec",
+    "preset_validator",
     "AbstractAppFieldType",
     "ContainerImage",
     "AutoscalingHPA",

--- a/src/apolo_app_types/protocols/common/__init__.py
+++ b/src/apolo_app_types/protocols/common/__init__.py
@@ -9,6 +9,7 @@ from .autoscaling import AutoscalingHPA
 from .base import AppInputs, AppOutputs
 from .buckets import Bucket
 from .containers import ContainerImage
+from .custom_validators import PRESET_VALIDATOR_NAME
 from .hugging_face import HuggingFaceCache, HuggingFaceModel, HuggingFaceToken
 from .ingress import (
     BaseIngress,
@@ -23,7 +24,11 @@ from .openai_compat import OpenAICompatChatAPI, OpenAICompatEmbeddingsAPI
 from .postgres import Postgres
 from .preset import Preset
 from .redis import Redis, RedisMaster
-from .schema_extra import SchemaExtraMetadata, SchemaMetaType
+from .schema_extra import (
+    X_CUSTOM_VALIDATORS_FIELD_NAME,
+    SchemaExtraMetadata,
+    SchemaMetaType,
+)
 from .secrets_ import ApoloSecret, OptionalSecret
 from .storage import (
     ApoloFilesFile,
@@ -69,6 +74,8 @@ __all__ = [
     "AppInputs",
     "SchemaExtraMetadata",
     "SchemaMetaType",
+    "X_CUSTOM_VALIDATORS_FIELD_NAME",
+    "PRESET_VALIDATOR_NAME",
     "AbstractAppFieldType",
     "ContainerImage",
     "AutoscalingHPA",

--- a/src/apolo_app_types/protocols/common/__init__.py
+++ b/src/apolo_app_types/protocols/common/__init__.py
@@ -10,7 +10,9 @@ from .base import AppInputs, AppOutputs
 from .buckets import Bucket
 from .containers import ContainerImage
 from .custom_validators import (
+    CUSTOM_VALIDATORS,
     PRESET_VALIDATOR_NAME,
+    CustomSchemaValidator,
     CustomValidatorSpec,
     PresetValidatorConfig,
     preset_validator,
@@ -80,7 +82,9 @@ __all__ = [
     "SchemaExtraMetadata",
     "SchemaMetaType",
     "X_CUSTOM_VALIDATORS_FIELD_NAME",
+    "CUSTOM_VALIDATORS",
     "PRESET_VALIDATOR_NAME",
+    "CustomSchemaValidator",
     "PresetValidatorConfig",
     "CustomValidatorSpec",
     "preset_validator",

--- a/src/apolo_app_types/protocols/common/custom_validators.py
+++ b/src/apolo_app_types/protocols/common/custom_validators.py
@@ -1,1 +1,26 @@
+from typing import TypedDict
+
+
 PRESET_VALIDATOR_NAME = "preset_validator"
+
+
+class PresetValidatorConfig(TypedDict, total=False):
+    exists: bool
+    min_vram_gb: int
+
+
+class CustomValidatorSpec(TypedDict, total=False):
+    preset_validator: PresetValidatorConfig
+
+
+def preset_validator(
+    *,
+    exists: bool | None = None,
+    min_vram_gb: int | None = None,
+) -> CustomValidatorSpec:
+    config: PresetValidatorConfig = {}
+    if exists is not None:
+        config["exists"] = exists
+    if min_vram_gb is not None:
+        config["min_vram_gb"] = min_vram_gb
+    return {"preset_validator": config}

--- a/src/apolo_app_types/protocols/common/custom_validators.py
+++ b/src/apolo_app_types/protocols/common/custom_validators.py
@@ -1,4 +1,7 @@
-from typing import TypedDict
+from collections.abc import Mapping
+from typing import Any, Awaitable, Callable, TypedDict
+
+import jsonschema.exceptions  # type: ignore[import-untyped]
 
 
 PRESET_VALIDATOR_NAME = "preset_validator"
@@ -6,7 +9,9 @@ PRESET_VALIDATOR_NAME = "preset_validator"
 
 class PresetValidatorConfig(TypedDict, total=False):
     exists: bool
-    min_vram_gb: int
+    min_cpu_cores: float
+    min_ram_gib: int
+    min_vram_gib: int
 
 
 class CustomValidatorSpec(TypedDict, total=False):
@@ -16,11 +21,147 @@ class CustomValidatorSpec(TypedDict, total=False):
 def preset_validator(
     *,
     exists: bool | None = None,
-    min_vram_gb: int | None = None,
+    min_cpu_cores: float | None = None,
+    min_ram_gib: int | None = None,
+    min_vram_gib: int | None = None,
 ) -> CustomValidatorSpec:
     config: PresetValidatorConfig = {}
     if exists is not None:
         config["exists"] = exists
-    if min_vram_gb is not None:
-        config["min_vram_gb"] = min_vram_gb
+    if min_cpu_cores is not None:
+        config["min_cpu_cores"] = min_cpu_cores
+    if min_ram_gib is not None:
+        config["min_ram_gib"] = min_ram_gib
+    if min_vram_gib is not None:
+        config["min_vram_gib"] = min_vram_gib
     return {"preset_validator": config}
+
+
+def _get_preset_name(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        name = value.get("name")
+        if isinstance(name, str):
+            return name
+    return None
+
+
+def _get_preset_max_vram_bytes(preset: Any) -> int | None:
+    vram_candidates: list[int] = []
+    for gpu in (preset.nvidia_gpu, preset.amd_gpu, preset.intel_gpu):
+        memory = getattr(gpu, "memory", None)
+        if isinstance(memory, int):
+            vram_candidates.append(memory)
+    nvidia_migs = getattr(preset, "nvidia_migs", None) or {}
+    for mig in nvidia_migs.values():
+        memory = getattr(mig, "memory", None)
+        if isinstance(memory, int):
+            vram_candidates.append(memory)
+    if not vram_candidates:
+        return None
+    return max(vram_candidates)
+
+
+def _get_preset_ram_bytes(preset: Any) -> int | None:
+    memory = getattr(preset, "memory", None)
+    if isinstance(memory, int):
+        return memory
+    return None
+
+
+def _build_custom_validation_error(
+    message: str, path: list[str | int], validator: str
+) -> jsonschema.exceptions.ValidationError:
+    return jsonschema.exceptions.ValidationError(
+        message=message,
+        path=path,
+        validator=validator,
+    )
+
+
+async def validate_preset_custom_validator(
+    value: Any,
+    validator_config: Mapping[str, Any],
+    *,
+    cluster_name: str,
+    path: list[str | int],
+    apolo_client: Any,
+) -> list[jsonschema.exceptions.ValidationError]:
+    preset_name = _get_preset_name(value)
+    if preset_name is None:
+        return []
+
+    presets = apolo_client.config.presets
+    preset = presets.get(preset_name)
+    errors: list[jsonschema.exceptions.ValidationError] = []
+    if validator_config.get("exists") is True and preset is None:
+        errors.append(
+            _build_custom_validation_error(
+                (
+                    f"Preset '{preset_name}' is not available on cluster "
+                    f"'{cluster_name}'."
+                ),
+                path,
+                PRESET_VALIDATOR_NAME,
+            )
+        )
+        return errors
+
+    min_cpu_cores = validator_config.get("min_cpu_cores")
+    if isinstance(min_cpu_cores, (int, float)) and preset is not None:
+        if getattr(preset, "cpu", None) is None or float(preset.cpu) < float(
+            min_cpu_cores
+        ):
+            errors.append(
+                _build_custom_validation_error(
+                    (
+                        f"Preset '{preset_name}' must provide at least "
+                        f"{min_cpu_cores} CPU cores on cluster "
+                        f"'{cluster_name}'."
+                    ),
+                    path,
+                    PRESET_VALIDATOR_NAME,
+                )
+            )
+
+    min_ram_gib = validator_config.get("min_ram_gib")
+    if isinstance(min_ram_gib, int) and preset is not None:
+        required_ram_bytes = min_ram_gib * 2**30
+        available_ram_bytes = _get_preset_ram_bytes(preset)
+        if available_ram_bytes is None or available_ram_bytes < required_ram_bytes:
+            errors.append(
+                _build_custom_validation_error(
+                    (
+                        f"Preset '{preset_name}' must provide at least "
+                        f"{min_ram_gib} GiB of RAM on cluster "
+                        f"'{cluster_name}'."
+                    ),
+                    path,
+                    PRESET_VALIDATOR_NAME,
+                )
+            )
+
+    min_vram_gib = validator_config.get("min_vram_gib")
+    if isinstance(min_vram_gib, int) and preset is not None:
+        required_vram_bytes = min_vram_gib * 2**30
+        available_vram_bytes = _get_preset_max_vram_bytes(preset)
+        if available_vram_bytes is None or available_vram_bytes < required_vram_bytes:
+            errors.append(
+                _build_custom_validation_error(
+                    (
+                        f"Preset '{preset_name}' must provide at least "
+                        f"{min_vram_gib} GiB of GPU memory on cluster "
+                        f"'{cluster_name}'."
+                    ),
+                    path,
+                    PRESET_VALIDATOR_NAME,
+                )
+            )
+    return errors
+
+
+CustomSchemaValidator = Callable[
+    ...,
+    Awaitable[list[jsonschema.exceptions.ValidationError]],
+]

--- a/src/apolo_app_types/protocols/common/custom_validators.py
+++ b/src/apolo_app_types/protocols/common/custom_validators.py
@@ -2,6 +2,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from numbers import Real
 from typing import Any, TypedDict
 
+
 PRESET_VALIDATOR_NAME = "preset_validator"
 
 

--- a/src/apolo_app_types/protocols/common/custom_validators.py
+++ b/src/apolo_app_types/protocols/common/custom_validators.py
@@ -1,7 +1,6 @@
-from collections.abc import Mapping
-from typing import Any, Awaitable, Callable, TypedDict
-
-import jsonschema.exceptions  # type: ignore[import-untyped]
+from collections.abc import Awaitable, Callable, Mapping
+from numbers import Real
+from typing import Any, TypedDict
 
 
 PRESET_VALIDATOR_NAME = "preset_validator"
@@ -16,6 +15,14 @@ class PresetValidatorConfig(TypedDict, total=False):
 
 class CustomValidatorSpec(TypedDict, total=False):
     preset_validator: PresetValidatorConfig
+
+
+class CustomValidationError(Exception):
+    def __init__(self, message: str, path: list[str | int], validator: str):
+        self.message = message
+        self.path = path
+        self.validator = validator
+        super().__init__(message)
 
 
 def preset_validator(
@@ -72,12 +79,8 @@ def _get_preset_ram_bytes(preset: Any) -> int | None:
 
 def _build_custom_validation_error(
     message: str, path: list[str | int], validator: str
-) -> jsonschema.exceptions.ValidationError:
-    return jsonschema.exceptions.ValidationError(
-        message=message,
-        path=path,
-        validator=validator,
-    )
+) -> CustomValidationError:
+    return CustomValidationError(message=message, path=path, validator=validator)
 
 
 async def validate_preset_custom_validator(
@@ -87,14 +90,14 @@ async def validate_preset_custom_validator(
     cluster_name: str,
     path: list[str | int],
     apolo_client: Any,
-) -> list[jsonschema.exceptions.ValidationError]:
+) -> list[CustomValidationError]:
     preset_name = _get_preset_name(value)
     if preset_name is None:
         return []
 
     presets = apolo_client.config.presets
     preset = presets.get(preset_name)
-    errors: list[jsonschema.exceptions.ValidationError] = []
+    errors: list[CustomValidationError] = []
     if validator_config.get("exists") is True and preset is None:
         errors.append(
             _build_custom_validation_error(
@@ -109,7 +112,7 @@ async def validate_preset_custom_validator(
         return errors
 
     min_cpu_cores = validator_config.get("min_cpu_cores")
-    if isinstance(min_cpu_cores, (int, float)) and preset is not None:
+    if isinstance(min_cpu_cores, Real) and preset is not None:
         if getattr(preset, "cpu", None) is None or float(preset.cpu) < float(
             min_cpu_cores
         ):
@@ -163,5 +166,5 @@ async def validate_preset_custom_validator(
 
 CustomSchemaValidator = Callable[
     ...,
-    Awaitable[list[jsonschema.exceptions.ValidationError]],
+    Awaitable[list[CustomValidationError]],
 ]

--- a/src/apolo_app_types/protocols/common/custom_validators.py
+++ b/src/apolo_app_types/protocols/common/custom_validators.py
@@ -2,9 +2,6 @@ from collections.abc import Awaitable, Callable, Mapping
 from numbers import Real
 from typing import Any, TypedDict
 
-from jsonschema.exceptions import ValidationError as JSONSchemaValidationError
-
-
 PRESET_VALIDATOR_NAME = "preset_validator"
 
 
@@ -19,12 +16,12 @@ class CustomValidatorSpec(TypedDict, total=False):
     preset_validator: PresetValidatorConfig
 
 
-class CustomValidationError(JSONSchemaValidationError):
+class CustomValidationError(Exception):
     def __init__(self, message: str, path: list[str | int], validator: str):
-        super().__init__(message)
         self.message = message
         self.path = list(path)
         self.validator = validator
+        super().__init__(message)
 
 
 def preset_validator(

--- a/src/apolo_app_types/protocols/common/custom_validators.py
+++ b/src/apolo_app_types/protocols/common/custom_validators.py
@@ -2,6 +2,8 @@ from collections.abc import Awaitable, Callable, Mapping
 from numbers import Real
 from typing import Any, TypedDict
 
+from jsonschema.exceptions import ValidationError as JSONSchemaValidationError
+
 
 PRESET_VALIDATOR_NAME = "preset_validator"
 
@@ -17,12 +19,12 @@ class CustomValidatorSpec(TypedDict, total=False):
     preset_validator: PresetValidatorConfig
 
 
-class CustomValidationError(Exception):
+class CustomValidationError(JSONSchemaValidationError):
     def __init__(self, message: str, path: list[str | int], validator: str):
-        self.message = message
-        self.path = path
-        self.validator = validator
         super().__init__(message)
+        self.message = message
+        self.path = list(path)
+        self.validator = validator
 
 
 def preset_validator(
@@ -172,3 +174,8 @@ CustomSchemaValidator = Callable[
     ...,
     Awaitable[list[CustomValidationError]],
 ]
+
+
+CUSTOM_VALIDATORS: dict[str, CustomSchemaValidator] = {
+    PRESET_VALIDATOR_NAME: validate_preset_custom_validator,
+}

--- a/src/apolo_app_types/protocols/common/custom_validators.py
+++ b/src/apolo_app_types/protocols/common/custom_validators.py
@@ -56,7 +56,11 @@ def _get_preset_name(value: Any) -> str | None:
 
 def _get_preset_max_vram_bytes(preset: Any) -> int | None:
     vram_candidates: list[int] = []
-    for gpu in (preset.nvidia_gpu, preset.amd_gpu, preset.intel_gpu):
+    for gpu in (
+        getattr(preset, "nvidia_gpu", None),
+        getattr(preset, "amd_gpu", None),
+        getattr(preset, "intel_gpu", None),
+    ):
         memory = getattr(gpu, "memory", None)
         if isinstance(memory, int):
             vram_candidates.append(memory)

--- a/src/apolo_app_types/protocols/common/custom_validators.py
+++ b/src/apolo_app_types/protocols/common/custom_validators.py
@@ -1,0 +1,1 @@
+PRESET_VALIDATOR_NAME = "preset_validator"

--- a/src/apolo_app_types/protocols/common/preset.py
+++ b/src/apolo_app_types/protocols/common/preset.py
@@ -13,7 +13,7 @@ class Preset(AbstractAppFieldType):
         json_schema_extra=SchemaExtraMetadata(
             title="Resource Preset",
             description="Select the resource preset used per service replica.",
-            custom_validators=[preset_validator(exists=true)],
+            custom_validators=[preset_validator(exists=True)],
         ).as_json_schema_extra(),
     )
     name: str = Field(

--- a/src/apolo_app_types/protocols/common/preset.py
+++ b/src/apolo_app_types/protocols/common/preset.py
@@ -12,6 +12,7 @@ class Preset(AbstractAppFieldType):
         json_schema_extra=SchemaExtraMetadata(
             title="Resource Preset",
             description="Select the resource preset used per service replica.",
+            custom_validators=[],
         ).as_json_schema_extra(),
     )
     name: str = Field(

--- a/src/apolo_app_types/protocols/common/preset.py
+++ b/src/apolo_app_types/protocols/common/preset.py
@@ -1,6 +1,7 @@
 from pydantic import ConfigDict, Field
 
 from apolo_app_types.protocols.common.abc_ import AbstractAppFieldType
+from apolo_app_types.protocols.common.custom_validators import preset_validator
 from apolo_app_types.protocols.common.schema_extra import (
     SchemaExtraMetadata,
 )
@@ -12,7 +13,7 @@ class Preset(AbstractAppFieldType):
         json_schema_extra=SchemaExtraMetadata(
             title="Resource Preset",
             description="Select the resource preset used per service replica.",
-            custom_validators=[],
+            custom_validators=[preset_validator()],
         ).as_json_schema_extra(),
     )
     name: str = Field(

--- a/src/apolo_app_types/protocols/common/preset.py
+++ b/src/apolo_app_types/protocols/common/preset.py
@@ -13,7 +13,7 @@ class Preset(AbstractAppFieldType):
         json_schema_extra=SchemaExtraMetadata(
             title="Resource Preset",
             description="Select the resource preset used per service replica.",
-            custom_validators=[preset_validator()],
+            custom_validators=[preset_validator(exists=true)],
         ).as_json_schema_extra(),
     )
     name: str = Field(

--- a/src/apolo_app_types/protocols/common/schema_extra.py
+++ b/src/apolo_app_types/protocols/common/schema_extra.py
@@ -3,6 +3,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from apolo_app_types.protocols.common.custom_validators import CustomValidatorSpec
+
 
 X_TITLE_FIELD_NAME = "x-title"
 X_DESCRIPTION_FIELD_NAME = "x-description"
@@ -17,9 +19,6 @@ class SchemaMetaType(enum.StrEnum):
     INLINE = "inline"
     INTEGRATION = "integration"
     DYNAMIC = "dynamic"
-
-
-CustomValidatorSpec = dict[str, Any]
 
 
 class SchemaExtraMetadata(BaseModel):

--- a/src/apolo_app_types/protocols/common/schema_extra.py
+++ b/src/apolo_app_types/protocols/common/schema_extra.py
@@ -10,12 +10,16 @@ X_LOGO_URL_FIELD_NAME = "x-logo-url"
 X_META_TYPE_FIELD_NAME = "x-meta-type"
 X_IS_CONFIGURABLE_FIELD_NAME = "x-is-configurable"
 X_IS_ADVANCED_FIELD_NAME = "x-is-advanced-field"
+X_CUSTOM_VALIDATORS_FIELD_NAME = "x-custom-validators"
 
 
 class SchemaMetaType(enum.StrEnum):
     INLINE = "inline"
     INTEGRATION = "integration"
     DYNAMIC = "dynamic"
+
+
+CustomValidatorSpec = dict[str, Any]
 
 
 class SchemaExtraMetadata(BaseModel):
@@ -28,6 +32,9 @@ class SchemaExtraMetadata(BaseModel):
     # If field can be collapsed in UI (more advanced setup)
     is_advanced_field: bool = Field(default=False, alias=X_IS_ADVANCED_FIELD_NAME)
     is_configurable: bool = Field(default=True, alias=X_IS_CONFIGURABLE_FIELD_NAME)
+    custom_validators: list[CustomValidatorSpec] | None = Field(
+        default=None, alias=X_CUSTOM_VALIDATORS_FIELD_NAME
+    )
     model_config = {"populate_by_name": True}
 
     def as_json_schema_extra(self) -> dict[str, Any]:

--- a/tests/unit/test_custom_validators.py
+++ b/tests/unit/test_custom_validators.py
@@ -129,7 +129,6 @@ def test_validate_preset_custom_validator_accepts_matching_preset() -> None:
     assert errors == []
 
 
-
 def test_custom_validators_registry_exposes_preset_validator() -> None:
     assert CUSTOM_VALIDATORS == {
         PRESET_VALIDATOR_NAME: validate_preset_custom_validator,

--- a/tests/unit/test_custom_validators.py
+++ b/tests/unit/test_custom_validators.py
@@ -22,12 +22,12 @@ def _gpu_preset(*, memory: int | None = None) -> SimpleNamespace:
 
 def test_validate_preset_custom_validator_reports_missing_preset() -> None:
     errors = asyncio.run(
-            validate_preset_custom_validator(
-                {"name": "preset-a"},
-                {"exists": True},
-                cluster_name="test-cluster",
-                path=["preset"],
-                apolo_client=_make_client(None),
+        validate_preset_custom_validator(
+            {"name": "preset-a"},
+            {"exists": True},
+            cluster_name="test-cluster",
+            path=["preset"],
+            apolo_client=_make_client(None),
         )
     )
 
@@ -72,26 +72,26 @@ def test_validate_preset_custom_validator_reports_missing_preset() -> None:
                 intel_gpu=None,
                 nvidia_migs={},
             ),
-                {
-                    "min_vram_gib": 10,
-                    "exists": True,
-                },
-                "GPU memory",
-            ),
-        ],
-    )
+            {
+                "min_vram_gib": 10,
+                "exists": True,
+            },
+            "GPU memory",
+        ),
+    ],
+)
 def test_validate_preset_custom_validator_reports_resource_mismatch(
     preset: object,
     validator_config: dict[str, object],
     expected_message_part: str,
 ) -> None:
     errors = asyncio.run(
-            validate_preset_custom_validator(
-                {"name": "preset-a"},
-                validator_config,
-                cluster_name="test-cluster",
-                path=["preset"],
-                apolo_client=_make_client(preset),
+        validate_preset_custom_validator(
+            {"name": "preset-a"},
+            validator_config,
+            cluster_name="test-cluster",
+            path=["preset"],
+            apolo_client=_make_client(preset),
         )
     )
 
@@ -101,7 +101,7 @@ def test_validate_preset_custom_validator_reports_resource_mismatch(
 
 def test_validate_preset_custom_validator_accepts_matching_preset() -> None:
     errors = asyncio.run(
-            validate_preset_custom_validator(
+        validate_preset_custom_validator(
             {"name": "preset-a"},
             {
                 "exists": True,

--- a/tests/unit/test_custom_validators.py
+++ b/tests/unit/test_custom_validators.py
@@ -1,0 +1,127 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from apolo_app_types.protocols.common.custom_validators import (
+    CustomValidationError,
+    validate_preset_custom_validator,
+)
+
+
+def _make_client(preset: object | None) -> MagicMock:
+    client = MagicMock()
+    client.config.presets = {"preset-a": preset}
+    return client
+
+
+def _gpu_preset(*, memory: int | None = None) -> SimpleNamespace:
+    return SimpleNamespace(memory=memory)
+
+
+def test_validate_preset_custom_validator_reports_missing_preset() -> None:
+    errors = asyncio.run(
+            validate_preset_custom_validator(
+                {"name": "preset-a"},
+                {"exists": True},
+                cluster_name="test-cluster",
+                path=["preset"],
+                apolo_client=_make_client(None),
+        )
+    )
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], CustomValidationError)
+    assert errors[0].validator == "preset_validator"
+
+
+@pytest.mark.parametrize(
+    ("preset", "validator_config", "expected_message_part"),
+    [
+        (
+            SimpleNamespace(
+                cpu=2.0,
+                memory=8 * (1 << 30),
+                nvidia_gpu=None,
+                amd_gpu=None,
+                intel_gpu=None,
+                nvidia_migs={},
+            ),
+            {"min_cpu_cores": 4},
+            "CPU cores",
+        ),
+        (
+            SimpleNamespace(
+                cpu=4.0,
+                memory=4 * (1 << 30),
+                nvidia_gpu=None,
+                amd_gpu=None,
+                intel_gpu=None,
+                nvidia_migs={},
+            ),
+            {"min_ram_gib": 8},
+            "RAM",
+        ),
+        (
+            SimpleNamespace(
+                cpu=4.0,
+                memory=8 * (1 << 30),
+                nvidia_gpu=_gpu_preset(memory=8 * (1 << 30)),
+                amd_gpu=None,
+                intel_gpu=None,
+                nvidia_migs={},
+            ),
+                {
+                    "min_vram_gib": 10,
+                    "exists": True,
+                },
+                "GPU memory",
+            ),
+        ],
+    )
+def test_validate_preset_custom_validator_reports_resource_mismatch(
+    preset: object,
+    validator_config: dict[str, object],
+    expected_message_part: str,
+) -> None:
+    errors = asyncio.run(
+            validate_preset_custom_validator(
+                {"name": "preset-a"},
+                validator_config,
+                cluster_name="test-cluster",
+                path=["preset"],
+                apolo_client=_make_client(preset),
+        )
+    )
+
+    assert errors
+    assert any(expected_message_part in error.message for error in errors)
+
+
+def test_validate_preset_custom_validator_accepts_matching_preset() -> None:
+    errors = asyncio.run(
+            validate_preset_custom_validator(
+            {"name": "preset-a"},
+            {
+                "exists": True,
+                "min_cpu_cores": 2,
+                "min_ram_gib": 4,
+                "min_vram_gib": 2,
+            },
+            cluster_name="test-cluster",
+            path=["preset"],
+            apolo_client=_make_client(
+                SimpleNamespace(
+                    cpu=4.0,
+                    memory=8 * (1 << 30),
+                    amd_gpu=None,
+                    intel_gpu=None,
+                    nvidia_gpu=SimpleNamespace(memory=2 * (1 << 30)),
+                    nvidia_migs={},
+                )
+            ),
+        )
+    )
+
+    assert errors == []

--- a/tests/unit/test_custom_validators.py
+++ b/tests/unit/test_custom_validators.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from apolo_app_types.protocols.common.custom_validators import (
+    CUSTOM_VALIDATORS,
+    PRESET_VALIDATOR_NAME,
     CustomValidationError,
     validate_preset_custom_validator,
 )
@@ -125,3 +127,10 @@ def test_validate_preset_custom_validator_accepts_matching_preset() -> None:
     )
 
     assert errors == []
+
+
+
+def test_custom_validators_registry_exposes_preset_validator() -> None:
+    assert CUSTOM_VALIDATORS == {
+        PRESET_VALIDATOR_NAME: validate_preset_custom_validator,
+    }

--- a/tests/unit/test_schema_extra.py
+++ b/tests/unit/test_schema_extra.py
@@ -1,0 +1,25 @@
+from apolo_app_types.protocols.common.schema_extra import SchemaExtraMetadata
+
+
+def test_schema_extra_metadata_serializes_custom_validators() -> None:
+    metadata = SchemaExtraMetadata(
+        title="Preset",
+        description="Preset requirements",
+        custom_validators=[
+            {
+                "preset_validator": {
+                    "exists": True,
+                    "min_vram_gb": 10,
+                }
+            }
+        ],
+    )
+
+    assert metadata.as_json_schema_extra()["x-custom-validators"] == [
+        {
+            "preset_validator": {
+                "exists": True,
+                "min_vram_gb": 10,
+            }
+        }
+    ]

--- a/tests/unit/test_schema_extra.py
+++ b/tests/unit/test_schema_extra.py
@@ -1,3 +1,4 @@
+from apolo_app_types.protocols.common.custom_validators import preset_validator
 from apolo_app_types.protocols.common.schema_extra import SchemaExtraMetadata
 
 
@@ -23,3 +24,12 @@ def test_schema_extra_metadata_serializes_custom_validators() -> None:
             }
         }
     ]
+
+
+def test_preset_validator_builder_serializes_expected_shape() -> None:
+    assert preset_validator(exists=True, min_vram_gb=10) == {
+        "preset_validator": {
+            "exists": True,
+            "min_vram_gb": 10,
+        }
+    }

--- a/tests/unit/test_schema_extra.py
+++ b/tests/unit/test_schema_extra.py
@@ -35,3 +35,7 @@ def test_preset_validator_builder_serializes_expected_shape() -> None:
             "min_vram_gib": 10,
         }
     }
+
+
+def test_preset_validator_builder_defaults_to_empty_config() -> None:
+    assert preset_validator() == {"preset_validator": {}}

--- a/tests/unit/test_schema_extra.py
+++ b/tests/unit/test_schema_extra.py
@@ -7,12 +7,7 @@ def test_schema_extra_metadata_serializes_custom_validators() -> None:
         title="Preset",
         description="Preset requirements",
         custom_validators=[
-            {
-                "preset_validator": {
-                    "exists": True,
-                    "min_vram_gb": 10,
-                }
-            }
+            preset_validator(exists=True, min_vram_gib=10),
         ],
     )
 
@@ -20,16 +15,23 @@ def test_schema_extra_metadata_serializes_custom_validators() -> None:
         {
             "preset_validator": {
                 "exists": True,
-                "min_vram_gb": 10,
+                "min_vram_gib": 10,
             }
         }
     ]
 
 
 def test_preset_validator_builder_serializes_expected_shape() -> None:
-    assert preset_validator(exists=True, min_vram_gb=10) == {
+    assert preset_validator(
+        exists=True,
+        min_cpu_cores=2.5,
+        min_ram_gib=16,
+        min_vram_gib=10,
+    ) == {
         "preset_validator": {
             "exists": True,
-            "min_vram_gb": 10,
+            "min_cpu_cores": 2.5,
+            "min_ram_gib": 16,
+            "min_vram_gib": 10,
         }
     }


### PR DESCRIPTION
## Summary
APS-77 preset-validation cleanup across backend, schema contracts, and UI:
- add schema-level `x-custom-validators`
- validate selected presets server-side
- expose cluster resource presets API
- re-check preset availability in the UI edit flow

## Verification
- `app-types`: `env ASDF_POETRY_VERSION=2.4.1 PYTHONPATH=src:fixtures make test-unit`
- `platform-apps`: `env ASDF_POETRY_VERSION=2.4.1 make test-unit`
- `platform-api`: `make test_integration`
- `neuro-web-ui`: `git push --force-with-lease`