### PR TITLE
fix: reflect CrunchyPostgresUserCredentials typing

### DIFF
--- a/src/apolo_app_types/protocols/postgres.py
+++ b/src/apolo_app_types/protocols/postgres.py
@@ -5,9 +5,9 @@ import typing as t
 from typing import Literal
 from urllib.parse import quote
 
-import apolo_sdk
 from pydantic import ConfigDict, Field, constr, model_validator
 
+import apolo_sdk
 from apolo_app_types.protocols.common import (
     AbstractAppFieldType,
     ApoloSecret,
@@ -222,14 +222,14 @@ class BasePostgresUserCredentials(AbstractAppFieldType):
         ).as_json_schema_extra(),
     )
     pgbouncer_host: str | None = Field(
-        ...,
+        default=None,
         json_schema_extra=SchemaExtraMetadata(
             description="Host of the PGBouncer instance.",
             title="PGBouncer Host",
         ).as_json_schema_extra(),
     )
     pgbouncer_port: int | None = Field(
-        default=...,
+        default=None,
         gt=0,
         json_schema_extra=SchemaExtraMetadata(
             description="Port of the PGBouncer instance.",


### PR DESCRIPTION
What changed

- Made `pgbouncer_host` and `pgbouncer_port` optional in `BasePostgresUserCredentials`.
- This is the source of truth for `CrunchyPostgresUserCredentials`, so the Superset schema can be generated from typing only.

Why

- Superset PR #6 should not carry a manually edited schema.
- The schema change needs to live in `app-types` so `make gen-types-schemas` stays the only way to update `SupersetInputs.json`.

Validation

- `poetry run ruff check src/apolo_app_types/protocols/postgres.py`
- `poetry run python -c "from apolo_app_types.protocols.postgres import BasePostgresUserCredentials as C; s=C.model_json_schema(); print(s['properties']['pgbouncer_host'].get('default')); print(s['properties']['pgbouncer_port'].get('default'))"`
