### PR TITLE
fix: IT-130 pin kubernetes client to <36 (v36 breaks in-cluster SA auth)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1538,22 +1538,21 @@ files = [
 
 [[package]]
 name = "kubernetes"
-version = "36.0.3"
+version = "35.0.0"
 description = "Kubernetes python client"
 optional = false
-python-versions = ">=3.10"
+python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "kubernetes-36.0.3-py2.py3-none-any.whl", hash = "sha256:8fde9241c4b298e6374a069dcf728359b4e72c2fb29489a975ba4e1c047cf10f"},
-    {file = "kubernetes-36.0.3.tar.gz", hash = "sha256:36993ed25ce59b789c9341473a228fcf268504a2fec7c2b2b1531d73072e5ce7"},
+    {file = "kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d"},
+    {file = "kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee"},
 ]
 
 [package.dependencies]
-aiohttp = ">=3.13.5,<4.0.0"
 certifi = ">=14.5.14"
 durationpy = ">=0.7"
 python-dateutil = ">=2.5.3"
-pyyaml = ">=6.0.3"
+pyyaml = ">=5.4.1"
 requests = "*"
 requests-oauthlib = "*"
 six = ">=1.9.0"
@@ -1561,6 +1560,7 @@ urllib3 = ">=1.24.2,<2.6.0 || >2.6.0"
 websocket-client = ">=0.32.0,<0.40.0 || >0.40.0,<0.41.dev0 || >=0.43.dev0"
 
 [package.extras]
+adal = ["adal (>=1.0.2)"]
 google-auth = ["google-auth (>=1.0.1)"]
 
 [[package]]
@@ -3132,4 +3132,4 @@ fixtures = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "7c03313151ee2ddbc5934d7be996b75d1d71040b329a8c578de0713b0ef2b7ef"
+content-hash = "4ce0c3232c3c896a9aa4c77ae911a28719dc38f4ab868e0f7bac1457e13475ef"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ python = ">=3.10,<4.0"
 apolo-sdk = "^26.3.0"
 click = "^8.3.2"
 httpx = "^0.28.0"
-kubernetes = ">=35,<37" # pinned due to https://github.com/kubernetes-client/python/issues/2458
+kubernetes = ">=35,<36" # 35.x only: >=35 for kubernetes-client/python#2458; <36 because v36 breaks in-cluster SA auth (requests sent as system:anonymous) — see IT-130
 pydantic = "^2.12.5"
 pyyaml = "^6.0.3"
 types-PyYAML = "^6.0.12.20260408"


### PR DESCRIPTION
## Problem
Workflow-type apps (Superset, etc.) install `healthy` but produce **no outputs** → no web-URL / no "Open App" button. The `update-outputs` post-install hook fails with:
```
services is forbidden: User "system:anonymous" cannot list resource "services" ...
```

## Root cause
The `kubernetes` python client **v36.x** regresses in-cluster ServiceAccount auth: with a valid mounted SA token, `config.load_incluster_config()` + an API call reaches the API server as `system:anonymous` (403). Our range `>=35,<37` (added for [kubernetes-client/python#2458](https://github.com/kubernetes-client/python/issues/2458)) admitted the broken v36 (lock had 36.0.3; app hook images shipped 36.0.0).

## Verified in-cluster (dev-gke), same pod / SA / token, only the client version changed
| kubernetes | result |
|---|---|
| 36.0.x | ❌ `system:anonymous` (403) |
| 35.0.0 | ✅ OK (lists services) |
| 31.0.0 | ✅ OK |

A raw HTTPS request from the same pod with the same token → **200**, and `kubectl auth whoami` under the SA authenticates correctly — so token / RBAC / cluster are fine; only the v36 client is broken.

## Fix
Tighten the pin to 35.x:
```
kubernetes = ">=35,<36"
```
`poetry lock` now resolves `kubernetes 35.0.0`. After release + rebuild of the app hook images (`mlops-app-*`), workflow-app outputs work again.

Same class of issue as IT-85 (a too-loose range pulled a broken version).

Related: IT-130.