### PR TITLE
fix: IT-131 redact tokens/secrets from app-types CLI logs

### DIFF
--- a/src/apolo_app_types/cli.py
+++ b/src/apolo_app_types/cli.py
@@ -2,7 +2,9 @@ import asyncio
 import json
 import logging
 import os
+import re
 import sys
+import typing as t
 from pathlib import Path
 
 import apolo_sdk
@@ -30,6 +32,31 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+_SENSITIVE_RE = re.compile(
+    r"token|password|secret|api[_-]?key|credential|authorization", re.IGNORECASE
+)
+_REDACTED = "***REDACTED***"
+
+
+def _redact(obj: t.Any) -> t.Any:
+    """Recursively mask sensitive values so tokens/passwords never reach logs."""
+    if isinstance(obj, dict):
+        # env-var entries: {"name": "APOLO_API_TOKEN", "value": "<token>"}
+        name = obj.get("name")
+        if isinstance(name, str) and "value" in obj and _SENSITIVE_RE.search(name):
+            return {**obj, "value": _REDACTED}
+        return {
+            k: (
+                _REDACTED
+                if isinstance(k, str) and _SENSITIVE_RE.search(k)
+                else _redact(v)
+            )
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_redact(item) for item in obj]
+    return obj
+
 
 @click.group()
 def cli() -> None:
@@ -56,12 +83,11 @@ def update_outputs(
     package_name: str | None,
 ) -> None:
     try:
-        logger.info("Helm input: %s", helm_outputs_json)
         if helm_outputs_json.startswith("'") and helm_outputs_json.endswith("'"):
             logger.info("Single quotes detected, removing them")
             helm_outputs_json = helm_outputs_json[1:-1]
         helm_outputs_dict = json.loads(helm_outputs_json)
-        logger.info("Helm outputs: %s", helm_outputs_dict)
+        logger.info("Helm input: %s", _redact(helm_outputs_dict))
         asyncio.run(
             update_app_outputs(
                 helm_outputs_dict,
@@ -134,7 +160,7 @@ def run_preprocessor(
                 raise ValueError(err_msg)
 
             loaded_inputs = inputs_class.model_validate(inputs_dict)
-            logger.info("Loaded inputs: %s", loaded_inputs)
+            logger.info("Loaded inputs: %s", _redact(loaded_inputs.model_dump()))
 
             preprocessor_class = load_app_preprocessor(
                 app_type, package_name, preprocessor_type


### PR DESCRIPTION
## Problem
The app-types CLI logs bearer tokens and passwords in **plaintext**, readable via `apolo app logs <id>`:
- `update-outputs` logged `Helm input:` / `Helm outputs:` — the full helm values incl. `cleanupEnvs`/`postProcessorEnvs` with `APOLO_API_TOKEN` / `APOLO_APPS_TOKEN`.
- `run-preprocessor` logged `Loaded inputs:` — the validated inputs model incl. the admin password (plaintext).

Observed on dev while debugging IT-130: a full, valid bearer token (`eyJ…`) in the hook pod log.

## Fix
Add a recursive `_redact()` that masks values whose **key or env `name`** matches `token|password|secret|api_key|credential|authorization`, and apply it to the three log sites (dropping the redundant pre-parse raw `Helm input` log). 
- Env entries `{"name":"APOLO_API_TOKEN","value":"…"}` → value `***REDACTED***`.
- Apolo-secret references (`{"key": "<name>"}`) are preserved — they name a secret, not its value.
- Non-sensitive fields unchanged (verified on a realistic payload).

## Follow-up (separate, not in this PR)
Tokens are still passed as **literal env values** into the hook (baked into the ArgoCD Application manifest by `platform-apps` `resources/workflow.yaml`). Not-logging them closes the log-leak (this ticket); passing them via k8s Secret / `secretKeyRef` is a deeper platform-apps hardening worth a follow-up.

Related: IT-131 (found during IT-130).